### PR TITLE
refactored code

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -15,9 +15,9 @@ type Ast struct {
 }
 
 // invoke the Visitor for each top level statement in the Ast
-func WalkAst(ast *Ast, v Visitor) {
+func WalkAst(ast *Ast, visitor Visitor) {
 	for _, stmt := range ast.Statements {
-		stmt.Accept(v)
+		stmt.Accept(visitor)
 	}
 }
 
@@ -81,25 +81,25 @@ type (
 	}
 )
 
-func (d *BadDecl) String() string  { return "BadDecl" }
-func (d *VarDecl) String() string  { return "VarDecl" }
-func (d *FuncDecl) String() string { return "FuncDecl" }
+func (decl *BadDecl) String() string  { return "BadDecl" }
+func (decl *VarDecl) String() string  { return "VarDecl" }
+func (decl *FuncDecl) String() string { return "FuncDecl" }
 
-func (d *BadDecl) Token() token.Token  { return d.Tok }
-func (d *VarDecl) Token() token.Token  { return d.Type }
-func (d *FuncDecl) Token() token.Token { return d.Func }
+func (decl *BadDecl) Token() token.Token  { return decl.Tok }
+func (decl *VarDecl) Token() token.Token  { return decl.Type }
+func (decl *FuncDecl) Token() token.Token { return decl.Func }
 
-func (d *BadDecl) GetRange() token.Range  { return d.Range }
-func (d *VarDecl) GetRange() token.Range  { return d.Range }
-func (d *FuncDecl) GetRange() token.Range { return d.Range }
+func (decl *BadDecl) GetRange() token.Range  { return decl.Range }
+func (decl *VarDecl) GetRange() token.Range  { return decl.Range }
+func (decl *FuncDecl) GetRange() token.Range { return decl.Range }
 
-func (d *BadDecl) Accept(v Visitor) Visitor  { return v.VisitBadDecl(d) }
-func (d *VarDecl) Accept(v Visitor) Visitor  { return v.VisitVarDecl(d) }
-func (d *FuncDecl) Accept(v Visitor) Visitor { return v.VisitFuncDecl(d) }
+func (decl *BadDecl) Accept(visitor Visitor) Visitor  { return visitor.VisitBadDecl(decl) }
+func (decl *VarDecl) Accept(visitor Visitor) Visitor  { return visitor.VisitVarDecl(decl) }
+func (decl *FuncDecl) Accept(visitor Visitor) Visitor { return visitor.VisitFuncDecl(decl) }
 
-func (d *BadDecl) declarationNode()  {}
-func (d *VarDecl) declarationNode()  {}
-func (d *FuncDecl) declarationNode() {}
+func (decl *BadDecl) declarationNode()  {}
+func (decl *VarDecl) declarationNode()  {}
+func (decl *FuncDecl) declarationNode() {}
 
 // Expressions
 type (
@@ -182,80 +182,80 @@ type (
 	}
 )
 
-func (e *BadExpr) String() string     { return "BadExpr" }
-func (e *Ident) String() string       { return "Ident" }
-func (e *Indexing) String() string    { return "Indexing" }
-func (e *IntLit) String() string      { return "IntLit" }
-func (e *FloatLit) String() string    { return "FloatLit" }
-func (e *BoolLit) String() string     { return "BoolLit" }
-func (e *CharLit) String() string     { return "CharLit" }
-func (e *StringLit) String() string   { return "StringLit" }
-func (e *UnaryExpr) String() string   { return "UnaryExpr" }
-func (e *BinaryExpr) String() string  { return "BinaryExpr" }
-func (e *TernaryExpr) String() string { return "BinaryExpr" }
-func (e *Grouping) String() string    { return "Grouping" }
-func (e *FuncCall) String() string    { return "FuncCall" }
+func (expr *BadExpr) String() string     { return "BadExpr" }
+func (expr *Ident) String() string       { return "Ident" }
+func (expr *Indexing) String() string    { return "Indexing" }
+func (expr *IntLit) String() string      { return "IntLit" }
+func (expr *FloatLit) String() string    { return "FloatLit" }
+func (expr *BoolLit) String() string     { return "BoolLit" }
+func (expr *CharLit) String() string     { return "CharLit" }
+func (expr *StringLit) String() string   { return "StringLit" }
+func (expr *UnaryExpr) String() string   { return "UnaryExpr" }
+func (expr *BinaryExpr) String() string  { return "BinaryExpr" }
+func (expr *TernaryExpr) String() string { return "BinaryExpr" }
+func (expr *Grouping) String() string    { return "Grouping" }
+func (expr *FuncCall) String() string    { return "FuncCall" }
 
-func (e *BadExpr) Token() token.Token     { return e.Tok }
-func (e *Ident) Token() token.Token       { return e.Literal }
-func (e *Indexing) Token() token.Token    { return e.Name.Token() }
-func (e *IntLit) Token() token.Token      { return e.Literal }
-func (e *FloatLit) Token() token.Token    { return e.Literal }
-func (e *BoolLit) Token() token.Token     { return e.Literal }
-func (e *CharLit) Token() token.Token     { return e.Literal }
-func (e *StringLit) Token() token.Token   { return e.Literal }
-func (e *UnaryExpr) Token() token.Token   { return e.Operator }
-func (e *BinaryExpr) Token() token.Token  { return e.Operator }
-func (e *TernaryExpr) Token() token.Token { return e.Operator }
-func (e *Grouping) Token() token.Token    { return e.LParen }
-func (e *FuncCall) Token() token.Token    { return e.Tok }
+func (expr *BadExpr) Token() token.Token     { return expr.Tok }
+func (expr *Ident) Token() token.Token       { return expr.Literal }
+func (expr *Indexing) Token() token.Token    { return expr.Name.Token() }
+func (expr *IntLit) Token() token.Token      { return expr.Literal }
+func (expr *FloatLit) Token() token.Token    { return expr.Literal }
+func (expr *BoolLit) Token() token.Token     { return expr.Literal }
+func (expr *CharLit) Token() token.Token     { return expr.Literal }
+func (expr *StringLit) Token() token.Token   { return expr.Literal }
+func (expr *UnaryExpr) Token() token.Token   { return expr.Operator }
+func (expr *BinaryExpr) Token() token.Token  { return expr.Operator }
+func (expr *TernaryExpr) Token() token.Token { return expr.Operator }
+func (expr *Grouping) Token() token.Token    { return expr.LParen }
+func (expr *FuncCall) Token() token.Token    { return expr.Tok }
 
-func (e *BadExpr) GetRange() token.Range { return e.Range }
-func (e *Ident) GetRange() token.Range   { return token.NewRange(e.Literal, e.Literal) }
-func (e *Indexing) GetRange() token.Range {
-	return token.Range{Start: e.Name.GetRange().Start, End: e.Index.GetRange().End}
+func (expr *BadExpr) GetRange() token.Range { return expr.Range }
+func (expr *Ident) GetRange() token.Range   { return token.NewRange(expr.Literal, expr.Literal) }
+func (expr *Indexing) GetRange() token.Range {
+	return token.Range{Start: expr.Name.GetRange().Start, End: expr.Index.GetRange().End}
 }
-func (e *IntLit) GetRange() token.Range      { return token.NewRange(e.Literal, e.Literal) }
-func (e *FloatLit) GetRange() token.Range    { return token.NewRange(e.Literal, e.Literal) }
-func (e *BoolLit) GetRange() token.Range     { return token.NewRange(e.Literal, e.Literal) }
-func (e *CharLit) GetRange() token.Range     { return token.NewRange(e.Literal, e.Literal) }
-func (e *StringLit) GetRange() token.Range   { return token.NewRange(e.Literal, e.Literal) }
-func (e *UnaryExpr) GetRange() token.Range   { return e.Range }
-func (e *BinaryExpr) GetRange() token.Range  { return e.Range }
-func (e *TernaryExpr) GetRange() token.Range { return e.Range }
-func (e *Grouping) GetRange() token.Range    { return e.Range }
-func (e *FuncCall) GetRange() token.Range    { return e.Range }
+func (expr *IntLit) GetRange() token.Range      { return token.NewRange(expr.Literal, expr.Literal) }
+func (expr *FloatLit) GetRange() token.Range    { return token.NewRange(expr.Literal, expr.Literal) }
+func (expr *BoolLit) GetRange() token.Range     { return token.NewRange(expr.Literal, expr.Literal) }
+func (expr *CharLit) GetRange() token.Range     { return token.NewRange(expr.Literal, expr.Literal) }
+func (expr *StringLit) GetRange() token.Range   { return token.NewRange(expr.Literal, expr.Literal) }
+func (expr *UnaryExpr) GetRange() token.Range   { return expr.Range }
+func (expr *BinaryExpr) GetRange() token.Range  { return expr.Range }
+func (expr *TernaryExpr) GetRange() token.Range { return expr.Range }
+func (expr *Grouping) GetRange() token.Range    { return expr.Range }
+func (expr *FuncCall) GetRange() token.Range    { return expr.Range }
 
-func (e *BadExpr) Accept(v Visitor) Visitor     { return v.VisitBadExpr(e) }
-func (e *Ident) Accept(v Visitor) Visitor       { return v.VisitIdent(e) }
-func (e *Indexing) Accept(v Visitor) Visitor    { return v.VisitIndexing(e) }
-func (e *IntLit) Accept(v Visitor) Visitor      { return v.VisitIntLit(e) }
-func (e *FloatLit) Accept(v Visitor) Visitor    { return v.VisitFLoatLit(e) }
-func (e *BoolLit) Accept(v Visitor) Visitor     { return v.VisitBoolLit(e) }
-func (e *CharLit) Accept(v Visitor) Visitor     { return v.VisitCharLit(e) }
-func (e *StringLit) Accept(v Visitor) Visitor   { return v.VisitStringLit(e) }
-func (e *UnaryExpr) Accept(v Visitor) Visitor   { return v.VisitUnaryExpr(e) }
-func (e *BinaryExpr) Accept(v Visitor) Visitor  { return v.VisitBinaryExpr(e) }
-func (e *TernaryExpr) Accept(v Visitor) Visitor { return v.VisitTernaryExpr(e) }
-func (e *Grouping) Accept(v Visitor) Visitor    { return v.VisitGrouping(e) }
-func (e *FuncCall) Accept(v Visitor) Visitor    { return v.VisitFuncCall(e) }
+func (expr *BadExpr) Accept(v Visitor) Visitor     { return v.VisitBadExpr(expr) }
+func (expr *Ident) Accept(v Visitor) Visitor       { return v.VisitIdent(expr) }
+func (expr *Indexing) Accept(v Visitor) Visitor    { return v.VisitIndexing(expr) }
+func (expr *IntLit) Accept(v Visitor) Visitor      { return v.VisitIntLit(expr) }
+func (expr *FloatLit) Accept(v Visitor) Visitor    { return v.VisitFLoatLit(expr) }
+func (expr *BoolLit) Accept(v Visitor) Visitor     { return v.VisitBoolLit(expr) }
+func (expr *CharLit) Accept(v Visitor) Visitor     { return v.VisitCharLit(expr) }
+func (expr *StringLit) Accept(v Visitor) Visitor   { return v.VisitStringLit(expr) }
+func (expr *UnaryExpr) Accept(v Visitor) Visitor   { return v.VisitUnaryExpr(expr) }
+func (expr *BinaryExpr) Accept(v Visitor) Visitor  { return v.VisitBinaryExpr(expr) }
+func (expr *TernaryExpr) Accept(v Visitor) Visitor { return v.VisitTernaryExpr(expr) }
+func (expr *Grouping) Accept(v Visitor) Visitor    { return v.VisitGrouping(expr) }
+func (expr *FuncCall) Accept(v Visitor) Visitor    { return v.VisitFuncCall(expr) }
 
-func (e *BadExpr) expressionNode()     {}
-func (e *Ident) expressionNode()       {}
-func (e *Indexing) expressionNode()    {}
-func (e *IntLit) expressionNode()      {}
-func (e *FloatLit) expressionNode()    {}
-func (e *BoolLit) expressionNode()     {}
-func (e *CharLit) expressionNode()     {}
-func (e *StringLit) expressionNode()   {}
-func (e *UnaryExpr) expressionNode()   {}
-func (e *BinaryExpr) expressionNode()  {}
-func (e *TernaryExpr) expressionNode() {}
-func (e *Grouping) expressionNode()    {}
-func (e *FuncCall) expressionNode()    {}
+func (expr *BadExpr) expressionNode()     {}
+func (expr *Ident) expressionNode()       {}
+func (expr *Indexing) expressionNode()    {}
+func (expr *IntLit) expressionNode()      {}
+func (expr *FloatLit) expressionNode()    {}
+func (expr *BoolLit) expressionNode()     {}
+func (expr *CharLit) expressionNode()     {}
+func (expr *StringLit) expressionNode()   {}
+func (expr *UnaryExpr) expressionNode()   {}
+func (expr *BinaryExpr) expressionNode()  {}
+func (expr *TernaryExpr) expressionNode() {}
+func (expr *Grouping) expressionNode()    {}
+func (expr *FuncCall) expressionNode()    {}
 
-func (e *Ident) assigneable()    {}
-func (e *Indexing) assigneable() {}
+func (expr *Ident) assigneable()    {}
+func (expr *Indexing) assigneable() {}
 
 // Statements
 type (
@@ -331,62 +331,62 @@ type (
 	}
 )
 
-func (s *BadStmt) String() string      { return "BadStmt" }
-func (s *DeclStmt) String() string     { return "DeclStmt" }
-func (s *ExprStmt) String() string     { return "ExprStmt" }
-func (s *AssignStmt) String() string   { return "AssignStmt" }
-func (s *BlockStmt) String() string    { return "BlockStmt" }
-func (s *IfStmt) String() string       { return "IfStmt" }
-func (s *WhileStmt) String() string    { return "WhileStmt" }
-func (s *ForStmt) String() string      { return "ForStmt" }
-func (s *ForRangeStmt) String() string { return "ForRangeStmt" }
-func (s *FuncCallStmt) String() string { return "FuncCallStmt" }
-func (s *ReturnStmt) String() string   { return "ReturnStmt" }
+func (stmt *BadStmt) String() string      { return "BadStmt" }
+func (stmt *DeclStmt) String() string     { return "DeclStmt" }
+func (stmt *ExprStmt) String() string     { return "ExprStmt" }
+func (stmt *AssignStmt) String() string   { return "AssignStmt" }
+func (stmt *BlockStmt) String() string    { return "BlockStmt" }
+func (stmt *IfStmt) String() string       { return "IfStmt" }
+func (stmt *WhileStmt) String() string    { return "WhileStmt" }
+func (stmt *ForStmt) String() string      { return "ForStmt" }
+func (stmt *ForRangeStmt) String() string { return "ForRangeStmt" }
+func (stmt *FuncCallStmt) String() string { return "FuncCallStmt" }
+func (stmt *ReturnStmt) String() string   { return "ReturnStmt" }
 
-func (s *BadStmt) Token() token.Token      { return s.Tok }
-func (s *DeclStmt) Token() token.Token     { return s.Decl.Token() }
-func (s *ExprStmt) Token() token.Token     { return s.Expr.Token() }
-func (s *AssignStmt) Token() token.Token   { return s.Tok }
-func (s *BlockStmt) Token() token.Token    { return s.Colon }
-func (s *IfStmt) Token() token.Token       { return s.If }
-func (s *WhileStmt) Token() token.Token    { return s.While }
-func (s *ForStmt) Token() token.Token      { return s.For }
-func (s *ForRangeStmt) Token() token.Token { return s.For }
-func (s *FuncCallStmt) Token() token.Token { return s.Call.Token() }
-func (s *ReturnStmt) Token() token.Token   { return s.Return }
+func (stmt *BadStmt) Token() token.Token      { return stmt.Tok }
+func (stmt *DeclStmt) Token() token.Token     { return stmt.Decl.Token() }
+func (stmt *ExprStmt) Token() token.Token     { return stmt.Expr.Token() }
+func (stmt *AssignStmt) Token() token.Token   { return stmt.Tok }
+func (stmt *BlockStmt) Token() token.Token    { return stmt.Colon }
+func (stmt *IfStmt) Token() token.Token       { return stmt.If }
+func (stmt *WhileStmt) Token() token.Token    { return stmt.While }
+func (stmt *ForStmt) Token() token.Token      { return stmt.For }
+func (stmt *ForRangeStmt) Token() token.Token { return stmt.For }
+func (stmt *FuncCallStmt) Token() token.Token { return stmt.Call.Token() }
+func (stmt *ReturnStmt) Token() token.Token   { return stmt.Return }
 
-func (s *BadStmt) GetRange() token.Range      { return s.Range }
-func (s *DeclStmt) GetRange() token.Range     { return s.Decl.GetRange() }
-func (s *ExprStmt) GetRange() token.Range     { return s.Expr.GetRange() }
-func (s *AssignStmt) GetRange() token.Range   { return s.Range }
-func (s *BlockStmt) GetRange() token.Range    { return s.Range }
-func (s *IfStmt) GetRange() token.Range       { return s.Range }
-func (s *WhileStmt) GetRange() token.Range    { return s.Range }
-func (s *ForStmt) GetRange() token.Range      { return s.Range }
-func (s *ForRangeStmt) GetRange() token.Range { return s.Range }
-func (s *FuncCallStmt) GetRange() token.Range { return s.Call.GetRange() }
-func (s *ReturnStmt) GetRange() token.Range   { return s.Range }
+func (stmt *BadStmt) GetRange() token.Range      { return stmt.Range }
+func (stmt *DeclStmt) GetRange() token.Range     { return stmt.Decl.GetRange() }
+func (stmt *ExprStmt) GetRange() token.Range     { return stmt.Expr.GetRange() }
+func (stmt *AssignStmt) GetRange() token.Range   { return stmt.Range }
+func (stmt *BlockStmt) GetRange() token.Range    { return stmt.Range }
+func (stmt *IfStmt) GetRange() token.Range       { return stmt.Range }
+func (stmt *WhileStmt) GetRange() token.Range    { return stmt.Range }
+func (stmt *ForStmt) GetRange() token.Range      { return stmt.Range }
+func (stmt *ForRangeStmt) GetRange() token.Range { return stmt.Range }
+func (stmt *FuncCallStmt) GetRange() token.Range { return stmt.Call.GetRange() }
+func (stmt *ReturnStmt) GetRange() token.Range   { return stmt.Range }
 
-func (s *BadStmt) Accept(v Visitor) Visitor      { return v.VisitBadStmt(s) }
-func (s *DeclStmt) Accept(v Visitor) Visitor     { return v.VisitDeclStmt(s) }
-func (s *ExprStmt) Accept(v Visitor) Visitor     { return v.VisitExprStmt(s) }
-func (s *AssignStmt) Accept(v Visitor) Visitor   { return v.VisitAssignStmt(s) }
-func (s *BlockStmt) Accept(v Visitor) Visitor    { return v.VisitBlockStmt(s) }
-func (s *IfStmt) Accept(v Visitor) Visitor       { return v.VisitIfStmt(s) }
-func (s *WhileStmt) Accept(v Visitor) Visitor    { return v.VisitWhileStmt(s) }
-func (s *ForStmt) Accept(v Visitor) Visitor      { return v.VisitForStmt(s) }
-func (s *ForRangeStmt) Accept(v Visitor) Visitor { return v.VisitForRangeStmt(s) }
-func (s *FuncCallStmt) Accept(v Visitor) Visitor { return v.VisitFuncCallStmt(s) }
-func (s *ReturnStmt) Accept(v Visitor) Visitor   { return v.VisitReturnStmt(s) }
+func (stmt *BadStmt) Accept(v Visitor) Visitor      { return v.VisitBadStmt(stmt) }
+func (stmt *DeclStmt) Accept(v Visitor) Visitor     { return v.VisitDeclStmt(stmt) }
+func (stmt *ExprStmt) Accept(v Visitor) Visitor     { return v.VisitExprStmt(stmt) }
+func (stmt *AssignStmt) Accept(v Visitor) Visitor   { return v.VisitAssignStmt(stmt) }
+func (stmt *BlockStmt) Accept(v Visitor) Visitor    { return v.VisitBlockStmt(stmt) }
+func (stmt *IfStmt) Accept(v Visitor) Visitor       { return v.VisitIfStmt(stmt) }
+func (stmt *WhileStmt) Accept(v Visitor) Visitor    { return v.VisitWhileStmt(stmt) }
+func (stmt *ForStmt) Accept(v Visitor) Visitor      { return v.VisitForStmt(stmt) }
+func (stmt *ForRangeStmt) Accept(v Visitor) Visitor { return v.VisitForRangeStmt(stmt) }
+func (stmt *FuncCallStmt) Accept(v Visitor) Visitor { return v.VisitFuncCallStmt(stmt) }
+func (stmt *ReturnStmt) Accept(v Visitor) Visitor   { return v.VisitReturnStmt(stmt) }
 
-func (s *BadStmt) statementNode()      {}
-func (s *DeclStmt) statementNode()     {}
-func (s *ExprStmt) statementNode()     {}
-func (s *AssignStmt) statementNode()   {}
-func (s *BlockStmt) statementNode()    {}
-func (s *IfStmt) statementNode()       {}
-func (s *WhileStmt) statementNode()    {}
-func (s *ForStmt) statementNode()      {}
-func (s *ForRangeStmt) statementNode() {}
-func (s *FuncCallStmt) statementNode() {}
-func (s *ReturnStmt) statementNode()   {}
+func (stmt *BadStmt) statementNode()      {}
+func (stmt *DeclStmt) statementNode()     {}
+func (stmt *ExprStmt) statementNode()     {}
+func (stmt *AssignStmt) statementNode()   {}
+func (stmt *BlockStmt) statementNode()    {}
+func (stmt *IfStmt) statementNode()       {}
+func (stmt *WhileStmt) statementNode()    {}
+func (stmt *ForStmt) statementNode()      {}
+func (stmt *ForRangeStmt) statementNode() {}
+func (stmt *FuncCallStmt) statementNode() {}
+func (stmt *ReturnStmt) statementNode()   {}

--- a/pkg/ast/printer.go
+++ b/pkg/ast/printer.go
@@ -14,171 +14,174 @@ type printer struct {
 
 // print the AST to stdout
 func (ast *Ast) Print() {
-	p := &printer{}
-	WalkAst(ast, p)
-	fmt.Println(p.returned)
+	printer := &printer{}
+	WalkAst(ast, printer)
+	fmt.Println(printer.returned)
 }
 
 func (ast *Ast) String() string {
-	p := &printer{}
-	WalkAst(ast, p)
-	return p.returned
+	printer := &printer{}
+	WalkAst(ast, printer)
+	return printer.returned
 }
 
-func (p *printer) printIdent() {
-	for i := 0; i < p.currentIdent; i++ {
-		p.print("   ")
+func (pr *printer) printIdent() {
+	for i := 0; i < pr.currentIdent; i++ {
+		pr.print("   ")
 	}
 }
 
-func (p *printer) print(s string) {
-	p.returned += s
+func (pr *printer) print(str string) {
+	pr.returned += str
 }
 
-func (p *printer) parenthesizeNode(name string, nodes ...Node) string {
-	p.print("(" + name)
-	p.currentIdent++
+func (pr *printer) parenthesizeNode(name string, nodes ...Node) string {
+	pr.print("(" + name)
+	pr.currentIdent++
+
 	for _, node := range nodes {
-		p.print("\n")
-		p.printIdent()
-		node.Accept(p)
+		pr.print("\n")
+		pr.printIdent()
+		node.Accept(pr)
 	}
-	p.currentIdent--
+
+	pr.currentIdent--
 	if len(nodes) != 0 {
-		p.printIdent()
+		pr.printIdent()
 	}
-	p.print(")\n")
-	return p.returned
+
+	pr.print(")\n")
+	return pr.returned
 }
 
-func (p *printer) VisitBadDecl(d *BadDecl) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("BadDecl[%s]", d.Tok.String()))
-	return p
+func (pr *printer) VisitBadDecl(decl *BadDecl) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("BadDecl[%s]", decl.Tok.String()))
+	return pr
 }
-func (p *printer) VisitVarDecl(d *VarDecl) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("VarDecl[%s]", d.Name.Literal), d.InitVal)
-	return p
+func (pr *printer) VisitVarDecl(decl *VarDecl) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("VarDecl[%s]", decl.Name.Literal), decl.InitVal)
+	return pr
 }
-func (p *printer) VisitFuncDecl(d *FuncDecl) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("FuncDecl[%s: %v, %v, %s]", d.Name.Literal, tokenSlice(d.ParamNames).literals(), d.ParamTypes, d.Type.String()), d.Body)
-	return p
+func (pr *printer) VisitFuncDecl(decl *FuncDecl) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("FuncDecl[%s: %v, %v, %s]", decl.Name.Literal, tokenSlice(decl.ParamNames).literals(), decl.ParamTypes, decl.Type.String()), decl.Body)
+	return pr
 }
 
-func (p *printer) VisitBadExpr(e *BadExpr) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("BadExpr[%s]", e.Tok.String()))
-	return p
+func (pr *printer) VisitBadExpr(expr *BadExpr) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("BadExpr[%s]", expr.Tok.String()))
+	return pr
 }
-func (p *printer) VisitIdent(e *Ident) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("Ident[%s]", e.Literal.Literal))
-	return p
+func (pr *printer) VisitIdent(expr *Ident) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("Ident[%s]", expr.Literal.Literal))
+	return pr
 }
-func (p *printer) VisitIndexing(e *Indexing) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("Indexing"), e.Name, e.Index)
-	return p
+func (pr *printer) VisitIndexing(expr *Indexing) Visitor {
+	pr.parenthesizeNode("Indexing", expr.Name, expr.Index)
+	return pr
 }
-func (p *printer) VisitIntLit(e *IntLit) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("IntLit(%d)", e.Value))
-	return p
+func (pr *printer) VisitIntLit(expr *IntLit) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("IntLit(%d)", expr.Value))
+	return pr
 }
-func (p *printer) VisitFLoatLit(e *FloatLit) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("FloatLit(%f)", e.Value))
-	return p
+func (pr *printer) VisitFLoatLit(expr *FloatLit) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("FloatLit(%f)", expr.Value))
+	return pr
 }
-func (p *printer) VisitBoolLit(e *BoolLit) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("BoolLit(%v)", e.Value))
-	return p
+func (pr *printer) VisitBoolLit(expr *BoolLit) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("BoolLit(%v)", expr.Value))
+	return pr
 }
-func (p *printer) VisitCharLit(e *CharLit) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("CharLit(%c)", e.Value))
-	return p
+func (pr *printer) VisitCharLit(expr *CharLit) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("CharLit(%c)", expr.Value))
+	return pr
 }
-func (p *printer) VisitStringLit(e *StringLit) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("StringLit[%s]", e.Token().Literal))
-	return p
+func (pr *printer) VisitStringLit(expr *StringLit) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("StringLit[%s]", expr.Token().Literal))
+	return pr
 }
-func (p *printer) VisitUnaryExpr(e *UnaryExpr) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("UnaryExpr[%s]", e.Operator.String()), e.Rhs)
-	return p
+func (pr *printer) VisitUnaryExpr(expr *UnaryExpr) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("UnaryExpr[%s]", expr.Operator.String()), expr.Rhs)
+	return pr
 }
-func (p *printer) VisitBinaryExpr(e *BinaryExpr) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("BinaryExpr[%s]", e.Operator.String()), e.Lhs, e.Rhs)
-	return p
+func (pr *printer) VisitBinaryExpr(expr *BinaryExpr) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("BinaryExpr[%s]", expr.Operator.String()), expr.Lhs, expr.Rhs)
+	return pr
 }
-func (p *printer) VisitTernaryExpr(e *TernaryExpr) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("TernaryExpr[%s]", e.Operator.String()), e.Lhs, e.Mid, e.Rhs)
-	return p
+func (pr *printer) VisitTernaryExpr(expr *TernaryExpr) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("TernaryExpr[%s]", expr.Operator.String()), expr.Lhs, expr.Mid, expr.Rhs)
+	return pr
 }
-func (p *printer) VisitGrouping(e *Grouping) Visitor {
-	p.parenthesizeNode("Grouping", e.Expr)
-	return p
+func (pr *printer) VisitGrouping(expr *Grouping) Visitor {
+	pr.parenthesizeNode("Grouping", expr.Expr)
+	return pr
 }
-func (p *printer) VisitFuncCall(e *FuncCall) Visitor {
+func (pr *printer) VisitFuncCall(expr *FuncCall) Visitor {
 	args := make([]Node, 0)
-	for _, v := range e.Args {
+	for _, v := range expr.Args {
 		args = append(args, v)
 	}
-	p.parenthesizeNode(fmt.Sprintf("FuncCall(%s)", e.Name), args...)
-	return p
+	pr.parenthesizeNode(fmt.Sprintf("FuncCall(%s)", expr.Name), args...)
+	return pr
 }
 
-func (p *printer) VisitBadStmt(s *BadStmt) Visitor {
-	p.parenthesizeNode(fmt.Sprintf("BadStmt[%s]", s.Tok.String()))
-	return p
+func (pr *printer) VisitBadStmt(stmt *BadStmt) Visitor {
+	pr.parenthesizeNode(fmt.Sprintf("BadStmt[%s]", stmt.Tok.String()))
+	return pr
 }
-func (p *printer) VisitDeclStmt(s *DeclStmt) Visitor {
-	p.parenthesizeNode("DeclStmt", s.Decl)
-	return p
+func (pr *printer) VisitDeclStmt(stmt *DeclStmt) Visitor {
+	pr.parenthesizeNode("DeclStmt", stmt.Decl)
+	return pr
 }
-func (p *printer) VisitExprStmt(s *ExprStmt) Visitor {
-	p.parenthesizeNode("ExprStmt", s.Expr)
-	return p
+func (pr *printer) VisitExprStmt(stmt *ExprStmt) Visitor {
+	pr.parenthesizeNode("ExprStmt", stmt.Expr)
+	return pr
 }
-func (p *printer) VisitAssignStmt(s *AssignStmt) Visitor {
-	p.parenthesizeNode("AssignStmt", s.Var, s.Rhs)
-	return p
+func (pr *printer) VisitAssignStmt(stmt *AssignStmt) Visitor {
+	pr.parenthesizeNode("AssignStmt", stmt.Var, stmt.Rhs)
+	return pr
 }
-func (p *printer) VisitBlockStmt(s *BlockStmt) Visitor {
-	args := make([]Node, len(s.Statements))
-	for i, v := range s.Statements {
+func (pr *printer) VisitBlockStmt(stmt *BlockStmt) Visitor {
+	args := make([]Node, len(stmt.Statements))
+	for i, v := range stmt.Statements {
 		args[i] = v
 	}
-	p.parenthesizeNode("BlockStmt", args...)
-	return p
+	pr.parenthesizeNode("BlockStmt", args...)
+	return pr
 }
-func (p *printer) VisitIfStmt(s *IfStmt) Visitor {
-	if s.Else != nil {
-		p.parenthesizeNode("IfStmt", s.Condition, s.Then, s.Else)
+func (pr *printer) VisitIfStmt(stmt *IfStmt) Visitor {
+	if stmt.Else != nil {
+		pr.parenthesizeNode("IfStmt", stmt.Condition, stmt.Then, stmt.Else)
 	} else {
-		p.parenthesizeNode("IfStmt", s.Condition, s.Then)
+		pr.parenthesizeNode("IfStmt", stmt.Condition, stmt.Then)
 	}
-	return p
+	return pr
 }
-func (p *printer) VisitWhileStmt(s *WhileStmt) Visitor {
-	p.parenthesizeNode("WhileStmt", s.Condition, s.Body)
-	return p
+func (pr *printer) VisitWhileStmt(stmt *WhileStmt) Visitor {
+	pr.parenthesizeNode("WhileStmt", stmt.Condition, stmt.Body)
+	return pr
 }
-func (p *printer) VisitForStmt(s *ForStmt) Visitor {
-	p.parenthesizeNode("ForStmt", s.Initializer, s.To, s.StepSize, s.Body)
-	return p
+func (pr *printer) VisitForStmt(stmt *ForStmt) Visitor {
+	pr.parenthesizeNode("ForStmt", stmt.Initializer, stmt.To, stmt.StepSize, stmt.Body)
+	return pr
 }
-func (p *printer) VisitForRangeStmt(s *ForRangeStmt) Visitor {
-	p.parenthesizeNode("ForRangeStmt", s.Initializer, s.In, s.Body)
-	return p
+func (pr *printer) VisitForRangeStmt(stmt *ForRangeStmt) Visitor {
+	pr.parenthesizeNode("ForRangeStmt", stmt.Initializer, stmt.In, stmt.Body)
+	return pr
 }
-func (p *printer) VisitFuncCallStmt(s *FuncCallStmt) Visitor {
-	p.parenthesizeNode("FuncCallStmt", s.Call)
-	return p
+func (pr *printer) VisitFuncCallStmt(stmt *FuncCallStmt) Visitor {
+	pr.parenthesizeNode("FuncCallStmt", stmt.Call)
+	return pr
 }
-func (p *printer) VisitReturnStmt(s *ReturnStmt) Visitor {
-	p.parenthesizeNode("ReturnStmt", s.Value)
-	return p
+func (pr *printer) VisitReturnStmt(stmt *ReturnStmt) Visitor {
+	pr.parenthesizeNode("ReturnStmt", stmt.Value)
+	return pr
 }
 
 type tokenSlice []token.Token
 
-func (t tokenSlice) literals() []string {
-	result := make([]string, 0, len(t))
-	for _, v := range t {
+func (tokens tokenSlice) literals() []string {
+	result := make([]string, 0, len(tokens))
+	for _, v := range tokens {
 		result = append(result, v.Literal)
 	}
 	return result

--- a/pkg/ast/symbol_table.go
+++ b/pkg/ast/symbol_table.go
@@ -20,84 +20,92 @@ func NewSymbolTable(enclosing *SymbolTable) *SymbolTable {
 }
 
 // returns the type of the variable name and if it exists in the table or it's enclosing scopes
-func (s *SymbolTable) LookupVar(name string) (token.TokenType, bool) {
-	if v, ok := s.variables[name]; !ok {
+func (scope *SymbolTable) LookupVar(name string) (token.TokenType, bool) {
+	if val, ok := scope.variables[name]; !ok {
 		// if the variable was not found here we recursively check the enclosing scopes
-		if s.Enclosing != nil {
-			return s.Enclosing.LookupVar(name)
+		if scope.Enclosing != nil {
+			return scope.Enclosing.LookupVar(name)
 		}
 		return token.ILLEGAL, false // variable doesn't exist
 	} else {
-		return v, true
+		return val, true
 	}
 }
 
 // returns the type of the variable name and if it exists in the table or it's enclosing scopes
-func (s *SymbolTable) LookupFunc(name string) (*FuncDecl, bool) {
-	if v, ok := s.functions[name]; !ok {
+func (scope *SymbolTable) LookupFunc(name string) (*FuncDecl, bool) {
+	if val, ok := scope.functions[name]; !ok {
 		// if the function was not found here we recursively check the enclosing scopes
-		if s.Enclosing != nil {
-			return s.Enclosing.LookupFunc(name)
+		if scope.Enclosing != nil {
+			return scope.Enclosing.LookupFunc(name)
 		}
 		return nil, false // function doesn't exist
 	} else {
-		return v, true
+		return val, true
 	}
 }
 
 // inserts a variable into the scope if it didn't exist yet
 // and returns wether it already existed
-func (s *SymbolTable) InsertVar(name string, typ token.TokenType) bool {
+func (scope *SymbolTable) InsertVar(name string, typ token.TokenType) bool {
 	switch typ {
 	case token.ZAHL, token.KOMMAZAHL, token.BOOLEAN, token.BUCHSTABE, token.TEXT:
 	default:
 		panic("invalid type argument")
 	}
-	if _, ok := s.variables[name]; ok {
+
+	if _, ok := scope.variables[name]; ok {
 		return true
 	}
-	s.variables[name] = typ
+
+	scope.variables[name] = typ
 	return false
 }
 
 // inserts a function into the scope if it didn't exist yet
 // and returns wether it already existed
-func (s *SymbolTable) InsertFunc(name string, fun *FuncDecl) bool {
+func (scope *SymbolTable) InsertFunc(name string, fun *FuncDecl) bool {
 	switch fun.Type.Type {
 	case token.ZAHL, token.KOMMAZAHL, token.BOOLEAN, token.BUCHSTABE, token.TEXT, token.NICHTS:
 	default:
 		panic("invalid type argument")
 	}
-	if _, ok := s.functions[name]; ok {
+
+	if _, ok := scope.functions[name]; ok {
 		return true
 	}
-	s.functions[name] = fun
+
+	scope.functions[name] = fun
 	return false
 }
 
-// merge other into s, replacing already existing symbols
-func (s *SymbolTable) Merge(other *SymbolTable) {
-	for k, v := range other.functions {
-		s.functions[k] = v
+// merge other into scope, replacing already existing symbols
+func (scope *SymbolTable) Merge(other *SymbolTable) {
+	for k, val := range other.functions {
+		scope.functions[k] = val
 	}
-	for k, v := range other.variables {
-		s.variables[k] = v
+
+	for k, val := range other.variables {
+		scope.variables[k] = val
 	}
 }
 
-// return a copy of s
+// return a copy of scope
 // not a deep copy, FuncDecl pointers stay the same
-func (s *SymbolTable) Copy() *SymbolTable {
+func (scope *SymbolTable) Copy() *SymbolTable {
 	table := &SymbolTable{
-		Enclosing: s.Enclosing,
+		Enclosing: scope.Enclosing,
 		variables: make(map[string]token.TokenType),
 		functions: make(map[string]*FuncDecl),
 	}
-	for k, v := range s.variables {
-		table.variables[k] = v
+
+	for k, val := range scope.variables {
+		table.variables[k] = val
 	}
-	for k, v := range s.functions {
-		table.functions[k] = v
+
+	for k, val := range scope.functions {
+		table.functions[k] = val
 	}
+
 	return table
 }

--- a/pkg/ast/typechecker/typechecker.go
+++ b/pkg/ast/typechecker/typechecker.go
@@ -29,13 +29,13 @@ func New(symbols *ast.SymbolTable, errorHandler scanner.ErrorHandler) *Typecheck
 
 // checks that all ast nodes fulfill type requirements
 func TypecheckAst(Ast *ast.Ast, errorHandler scanner.ErrorHandler) {
-	t := New(Ast.Symbols, errorHandler)
+	typechecker := New(Ast.Symbols, errorHandler)
 
 	for i, l := 0, len(Ast.Statements); i < l; i++ {
-		Ast.Statements[i].Accept(t)
+		Ast.Statements[i].Accept(typechecker)
 	}
 
-	if t.Errored {
+	if typechecker.Errored {
 		Ast.Faulty = true
 	}
 }
@@ -47,7 +47,7 @@ func (t *Typechecker) TypecheckNode(node ast.Node) *Typechecker {
 
 // helper to visit a node
 func (t *Typechecker) visit(node ast.Node) {
-	t = node.Accept(t).(*Typechecker)
+	node.Accept(t)
 }
 
 // Evaluates the type of an expression
@@ -89,99 +89,105 @@ func (t *Typechecker) errExpectedTern(tok token.Token, t1, t2, t3, op token.Toke
 	t.err(tok, fmt.Sprintf("Die Typen Kombination aus '%s', '%s' und '%s' passt nicht zu dem '%s' Operator", t1, t2, t3, op))
 }
 
-func (t *Typechecker) VisitBadDecl(d *ast.BadDecl) ast.Visitor {
+func (t *Typechecker) VisitBadDecl(decl *ast.BadDecl) ast.Visitor {
 	t.Errored = true
 	t.latestReturnedType = token.NICHTS
 	return t
 }
-func (t *Typechecker) VisitVarDecl(d *ast.VarDecl) ast.Visitor {
-	ty := t.Evaluate(d.InitVal)
-	if ty != d.Type.Type {
-		t.err(d.InitVal.Token(), fmt.Sprintf(
+func (t *Typechecker) VisitVarDecl(decl *ast.VarDecl) ast.Visitor {
+	tokenType := t.Evaluate(decl.InitVal)
+	if tokenType != decl.Type.Type {
+		t.err(decl.InitVal.Token(), fmt.Sprintf(
 			"Ein Wert vom Typ %s kann keiner Variable vom Typ %s zugewiesen werden",
-			ty,
-			d.Type.Type,
+			tokenType,
+			decl.Type.Type,
 		))
 	}
 	return t
 }
-func (t *Typechecker) VisitFuncDecl(d *ast.FuncDecl) ast.Visitor {
-	t.funcArgs[d.Name.Literal] = make(map[string]token.TokenType)
-	for i, l := 0, len(d.ParamNames); i < l; i++ {
-		t.funcArgs[d.Name.Literal][d.ParamNames[i].Literal] = d.ParamTypes[i].Type
+func (t *Typechecker) VisitFuncDecl(decl *ast.FuncDecl) ast.Visitor {
+	t.funcArgs[decl.Name.Literal] = make(map[string]token.TokenType)
+	for i, l := 0, len(decl.ParamNames); i < l; i++ {
+		t.funcArgs[decl.Name.Literal][decl.ParamNames[i].Literal] = decl.ParamTypes[i].Type
 	}
-	return d.Body.Accept(t)
+
+	return decl.Body.Accept(t)
 }
 
-func (t *Typechecker) VisitBadExpr(e *ast.BadExpr) ast.Visitor {
+func (t *Typechecker) VisitBadExpr(expr *ast.BadExpr) ast.Visitor {
 	t.Errored = true
 	t.latestReturnedType = token.NICHTS
 	return t
 }
-func (t *Typechecker) VisitIdent(e *ast.Ident) ast.Visitor {
-	t.latestReturnedType, _ = t.CurrentTable.LookupVar(e.Literal.Literal)
+func (t *Typechecker) VisitIdent(expr *ast.Ident) ast.Visitor {
+	t.latestReturnedType, _ = t.CurrentTable.LookupVar(expr.Literal.Literal)
 	return t
 }
-func (t *Typechecker) VisitIndexing(e *ast.Indexing) ast.Visitor {
-	if t.Evaluate(e.Index) != token.ZAHL {
-		t.err(e.Index.Token(), "Der STELLE Operator erwartet eine Zahl als zweiten Operanden")
+func (t *Typechecker) VisitIndexing(expr *ast.Indexing) ast.Visitor {
+	if t.Evaluate(expr.Index) != token.ZAHL {
+		t.err(expr.Index.Token(), "Der STELLE Operator erwartet eine Zahl als zweiten Operanden")
 	}
-	if t.Evaluate(e.Name) != token.TEXT {
-		t.err(e.Name.Token(), "Der STELLE Operator erwartet einen Text als ersten Operanden")
+
+	if t.Evaluate(expr.Name) != token.TEXT {
+		t.err(expr.Name.Token(), "Der STELLE Operator erwartet einen Text als ersten Operanden")
 	}
+
 	t.latestReturnedType = token.BUCHSTABE // later on the list element type
 	return t
 }
-func (t *Typechecker) VisitIntLit(e *ast.IntLit) ast.Visitor {
+func (t *Typechecker) VisitIntLit(expr *ast.IntLit) ast.Visitor {
 	t.latestReturnedType = token.ZAHL
 	return t
 }
-func (t *Typechecker) VisitFLoatLit(e *ast.FloatLit) ast.Visitor {
+func (t *Typechecker) VisitFLoatLit(expr *ast.FloatLit) ast.Visitor {
 	t.latestReturnedType = token.KOMMAZAHL
 	return t
 }
-func (t *Typechecker) VisitBoolLit(e *ast.BoolLit) ast.Visitor {
+func (t *Typechecker) VisitBoolLit(expr *ast.BoolLit) ast.Visitor {
 	t.latestReturnedType = token.BOOLEAN
 	return t
 }
-func (t *Typechecker) VisitCharLit(e *ast.CharLit) ast.Visitor {
+func (t *Typechecker) VisitCharLit(expr *ast.CharLit) ast.Visitor {
 	t.latestReturnedType = token.BUCHSTABE
 	return t
 }
-func (t *Typechecker) VisitStringLit(e *ast.StringLit) ast.Visitor {
+func (t *Typechecker) VisitStringLit(expr *ast.StringLit) ast.Visitor {
 	t.latestReturnedType = token.TEXT
 	return t
 }
-func (t *Typechecker) VisitUnaryExpr(e *ast.UnaryExpr) ast.Visitor {
+func (t *Typechecker) VisitUnaryExpr(expr *ast.UnaryExpr) ast.Visitor {
 	// Evaluate the rhs expression and check if the operator fits it
-	rhs := t.Evaluate(e.Rhs)
+	rhs := t.Evaluate(expr.Rhs)
 	// boolean vs bitwise negate (compound assignement)
-	/*if e.Operator.Type == token.NEGIERE && rhs == token.ZAHL {
-		e.Operator.Type == token.LOGISCHNICHT
+	/*if expr.Operator.Type == token.NEGIERE && rhs == token.ZAHL {
+		expr.Operator.Type == token.LOGISCHNICHT
 	}*/
-	switch e.Operator.Type {
+	switch expr.Operator.Type {
 	case token.BETRAG, token.NEGATE:
 		if !isType(rhs, token.ZAHL, token.KOMMAZAHL) {
-			t.errExpected(e.Operator, rhs, token.ZAHL, token.KOMMAZAHL)
+			t.errExpected(expr.Operator, rhs, token.ZAHL, token.KOMMAZAHL)
 		}
 	case token.NICHT:
 		if !isType(rhs, token.BOOLEAN) {
-			t.errExpected(e.Operator, rhs, token.BOOLEAN)
+			t.errExpected(expr.Operator, rhs, token.BOOLEAN)
 		}
+
 		t.latestReturnedType = token.BOOLEAN
 	case token.NEGIERE:
 		if !isType(rhs, token.BOOLEAN, token.ZAHL) {
-			t.errExpected(e.Operator, rhs, token.BOOLEAN, token.ZAHL)
+			t.errExpected(expr.Operator, rhs, token.BOOLEAN, token.ZAHL)
 		}
 	case token.LOGISCHNICHT:
 		if !isType(rhs, token.ZAHL) {
-			t.errExpected(e.Operator, rhs, token.ZAHL)
+			t.errExpected(expr.Operator, rhs, token.ZAHL)
 		}
+
 		t.latestReturnedType = token.ZAHL
 	case token.LÄNGE:
 		if !isType(rhs, token.TEXT) {
-			t.errExpected(e.Operator, rhs, token.TEXT)
+			t.errExpected(expr.Operator, rhs, token.TEXT)
 		}
+
 		t.latestReturnedType = token.ZAHL // some operators change the type of the rhs expression, so we set that
 	case token.GRÖßE:
 		t.latestReturnedType = token.ZAHL
@@ -189,51 +195,57 @@ func (t *Typechecker) VisitUnaryExpr(e *ast.UnaryExpr) ast.Visitor {
 		token.ARKSIN, token.ARKKOS, token.ARKTAN,
 		token.HYPSIN, token.HYPKOS, token.HYPTAN:
 		if !isType(rhs, token.ZAHL, token.KOMMAZAHL) {
-			t.errExpected(e.Operator, rhs, token.ZAHL, token.KOMMAZAHL)
+			t.errExpected(expr.Operator, rhs, token.ZAHL, token.KOMMAZAHL)
 		}
+
 		t.latestReturnedType = token.KOMMAZAHL
 	case token.ZAHL:
 		if !isType(rhs, token.KOMMAZAHL, token.ZAHL, token.TEXT, token.BOOLEAN, token.BUCHSTABE) {
-			t.errExpected(e.Operator, rhs, token.KOMMAZAHL, token.ZAHL, token.TEXT, token.BOOLEAN, token.BUCHSTABE)
+			t.errExpected(expr.Operator, rhs, token.KOMMAZAHL, token.ZAHL, token.TEXT, token.BOOLEAN, token.BUCHSTABE)
 		}
+
 		t.latestReturnedType = token.ZAHL
 	case token.KOMMAZAHL:
 		if !isType(rhs, token.TEXT, token.ZAHL, token.KOMMAZAHL) {
-			t.errExpected(e.Operator, rhs, token.ZAHL, token.TEXT, token.KOMMAZAHL)
+			t.errExpected(expr.Operator, rhs, token.ZAHL, token.TEXT, token.KOMMAZAHL)
 		}
+
 		t.latestReturnedType = token.KOMMAZAHL
 	case token.BOOLEAN:
 		if !isType(rhs, token.ZAHL, token.BOOLEAN) {
-			t.errExpected(e.Operator, rhs, token.ZAHL, token.BOOLEAN)
+			t.errExpected(expr.Operator, rhs, token.ZAHL, token.BOOLEAN)
 		}
+
 		t.latestReturnedType = token.BOOLEAN
 	case token.BUCHSTABE:
 		if !isType(rhs, token.ZAHL, token.BUCHSTABE) {
-			t.errExpected(e.Operator, rhs, token.ZAHL, token.BUCHSTABE)
+			t.errExpected(expr.Operator, rhs, token.ZAHL, token.BUCHSTABE)
 		}
+
 		t.latestReturnedType = token.BUCHSTABE
 	case token.TEXT:
 		if !isType(rhs, token.ZAHL, token.KOMMAZAHL, token.BOOLEAN, token.TEXT, token.BUCHSTABE) {
-			t.errExpected(e.Operator, rhs, token.ZAHL, token.KOMMAZAHL, token.BOOLEAN, token.TEXT, token.BUCHSTABE)
+			t.errExpected(expr.Operator, rhs, token.ZAHL, token.KOMMAZAHL, token.BOOLEAN, token.TEXT, token.BUCHSTABE)
 		}
+
 		t.latestReturnedType = token.TEXT
 	default:
-		t.err(e.Operator, fmt.Sprintf("Unbekannter unärer Operator '%s'", e.Operator.String()))
+		t.err(expr.Operator, fmt.Sprintf("Unbekannter unärer Operator '%s'", expr.Operator.String()))
 	}
 	return t
 }
-func (t *Typechecker) VisitBinaryExpr(e *ast.BinaryExpr) ast.Visitor {
-	lhs := t.Evaluate(e.Lhs)
-	rhs := t.Evaluate(e.Rhs)
+func (t *Typechecker) VisitBinaryExpr(expr *ast.BinaryExpr) ast.Visitor {
+	lhs := t.Evaluate(expr.Lhs)
+	rhs := t.Evaluate(expr.Rhs)
 
 	// helper to validate if types match
 	validate := func(op token.TokenType, valid ...token.TokenType) {
 		if !isTypeBin(lhs, rhs, valid...) {
-			t.errExpectedBin(e.Token(), lhs, rhs, op)
+			t.errExpectedBin(expr.Token(), lhs, rhs, op)
 		}
 	}
 
-	switch op := e.Operator.Type; op {
+	switch op := expr.Operator.Type; op {
 	case token.VERKETTET:
 		validate(op, token.TEXT, token.BUCHSTABE)
 		t.latestReturnedType = token.TEXT // some operators change the type of the expression, so we set that here
@@ -241,6 +253,7 @@ func (t *Typechecker) VisitBinaryExpr(e *ast.BinaryExpr) ast.Visitor {
 		token.MINUS, token.SUBTRAHIERE, token.VERRINGERE,
 		token.MAL, token.MULTIPLIZIERE, token.VERVIELFACHE:
 		validate(op, token.ZAHL, token.KOMMAZAHL)
+
 		if lhs == token.ZAHL && rhs == token.ZAHL {
 			t.latestReturnedType = token.ZAHL
 		} else {
@@ -248,11 +261,12 @@ func (t *Typechecker) VisitBinaryExpr(e *ast.BinaryExpr) ast.Visitor {
 		}
 	case token.STELLE:
 		if lhs != token.TEXT {
-			t.err(e.Lhs.Token(), "Der STELLE Operator erwartet einen Text als ersten Operanden")
+			t.err(expr.Lhs.Token(), "Der STELLE Operator erwartet einen Text als ersten Operanden")
 		}
 		if rhs != token.ZAHL {
-			t.err(e.Lhs.Token(), "Der STELLE Operator erwartet eine Zahl als zweiten Operanden")
+			t.err(expr.Lhs.Token(), "Der STELLE Operator erwartet eine Zahl als zweiten Operanden")
 		}
+
 		t.latestReturnedType = token.BUCHSTABE // later on the list element type
 	case token.DURCH, token.DIVIDIERE, token.TEILE, token.HOCH, token.LOGARITHMUS:
 		validate(op, token.ZAHL, token.KOMMAZAHL)
@@ -274,13 +288,15 @@ func (t *Typechecker) VisitBinaryExpr(e *ast.BinaryExpr) ast.Visitor {
 		t.latestReturnedType = token.ZAHL
 	case token.GLEICH:
 		if lhs != rhs {
-			t.errExpectedBin(e.Token(), lhs, rhs, op)
+			t.errExpectedBin(expr.Token(), lhs, rhs, op)
 		}
+
 		t.latestReturnedType = token.BOOLEAN
 	case token.UNGLEICH:
 		if lhs != rhs {
-			t.errExpectedBin(e.Token(), lhs, rhs, op)
+			t.errExpectedBin(expr.Token(), lhs, rhs, op)
 		}
+
 		t.latestReturnedType = token.BOOLEAN
 	case token.GRÖßERODER, token.KLEINER, token.KLEINERODER, token.GRÖßER:
 		validate(op, token.ZAHL, token.KOMMAZAHL)
@@ -289,74 +305,76 @@ func (t *Typechecker) VisitBinaryExpr(e *ast.BinaryExpr) ast.Visitor {
 		validate(op, token.ZAHL)
 		t.latestReturnedType = token.ZAHL
 	default:
-		t.err(e.Operator, fmt.Sprintf("Unbekannter binärer Operator '%s'", e.Operator.String()))
+		t.err(expr.Operator, fmt.Sprintf("Unbekannter binärer Operator '%s'", expr.Operator.String()))
 	}
 	return t
 }
-func (t *Typechecker) VisitTernaryExpr(e *ast.TernaryExpr) ast.Visitor {
-	lhs := t.Evaluate(e.Lhs)
-	mid := t.Evaluate(e.Mid)
-	rhs := t.Evaluate(e.Rhs)
+func (t *Typechecker) VisitTernaryExpr(expr *ast.TernaryExpr) ast.Visitor {
+	lhs := t.Evaluate(expr.Lhs)
+	mid := t.Evaluate(expr.Mid)
+	rhs := t.Evaluate(expr.Rhs)
 
 	// helper to validate if types match
 	validateBin := func(op token.TokenType, valid ...token.TokenType) {
 		if !isTypeBin(mid, rhs, valid...) {
-			t.errExpectedTern(e.Token(), lhs, mid, rhs, op)
+			t.errExpectedTern(expr.Token(), lhs, mid, rhs, op)
 		}
 	}
 
-	switch e.Operator.Type {
+	switch expr.Operator.Type {
 	case token.VONBIS:
 		if lhs != token.TEXT {
-			t.errExpectedTern(e.Token(), lhs, mid, rhs, e.Operator.Type)
+			t.errExpectedTern(expr.Token(), lhs, mid, rhs, expr.Operator.Type)
 		}
-		validateBin(e.Operator.Type, token.ZAHL)
+
+		validateBin(expr.Operator.Type, token.ZAHL)
 		t.latestReturnedType = token.TEXT
 	default:
-		t.err(e.Operator, fmt.Sprintf("Unbekannter ternärer Operator '%s'", e.Operator.String()))
+		t.err(expr.Operator, fmt.Sprintf("Unbekannter ternärer Operator '%s'", expr.Operator.String()))
 	}
 	return t
 }
-func (t *Typechecker) VisitGrouping(e *ast.Grouping) ast.Visitor {
-	return e.Expr.Accept(t)
+func (t *Typechecker) VisitGrouping(expr *ast.Grouping) ast.Visitor {
+	return expr.Expr.Accept(t)
 }
-func (t *Typechecker) VisitFuncCall(e *ast.FuncCall) ast.Visitor {
-	for k, v := range e.Args {
-		ty := t.Evaluate(v)
-		if ty != t.funcArgs[e.Name][k] {
-			t.err(v.Token(), fmt.Sprintf(
+func (t *Typechecker) VisitFuncCall(callExpr *ast.FuncCall) ast.Visitor {
+	for k, expr := range callExpr.Args {
+		tokenType := t.Evaluate(expr)
+
+		if tokenType != t.funcArgs[callExpr.Name][k] {
+			t.err(expr.Token(), fmt.Sprintf(
 				"Die Funktion %s erwartet einen Wert vom Typ %s für den Parameter %s, aber hat %s bekommen",
-				e.Name,
-				t.funcArgs[e.Name][k],
+				callExpr.Name,
+				t.funcArgs[callExpr.Name][k],
 				k,
-				ty,
+				tokenType,
 			))
 		}
 	}
-	fun, _ := t.CurrentTable.LookupFunc(e.Name)
+	fun, _ := t.CurrentTable.LookupFunc(callExpr.Name)
 	t.latestReturnedType = fun.Type.Type
 	return t
 }
 
-func (t *Typechecker) VisitBadStmt(s *ast.BadStmt) ast.Visitor {
+func (t *Typechecker) VisitBadStmt(stmt *ast.BadStmt) ast.Visitor {
 	t.Errored = true
 	t.latestReturnedType = token.NICHTS
 	return t
 }
-func (t *Typechecker) VisitDeclStmt(s *ast.DeclStmt) ast.Visitor {
-	return s.Decl.Accept(t)
+func (t *Typechecker) VisitDeclStmt(stmt *ast.DeclStmt) ast.Visitor {
+	return stmt.Decl.Accept(t)
 }
-func (t *Typechecker) VisitExprStmt(s *ast.ExprStmt) ast.Visitor {
-	return s.Expr.Accept(t)
+func (t *Typechecker) VisitExprStmt(stmt *ast.ExprStmt) ast.Visitor {
+	return stmt.Expr.Accept(t)
 }
-func (t *Typechecker) VisitAssignStmt(s *ast.AssignStmt) ast.Visitor {
-	ty := t.Evaluate(s.Rhs)
-	switch assign := s.Var.(type) {
+func (t *Typechecker) VisitAssignStmt(stmt *ast.AssignStmt) ast.Visitor {
+	tokenType := t.Evaluate(stmt.Rhs)
+	switch assign := stmt.Var.(type) {
 	case *ast.Ident:
-		if vartyp, exists := t.CurrentTable.LookupVar(assign.Literal.Literal); exists && vartyp != ty {
-			t.err(s.Rhs.Token(), fmt.Sprintf(
+		if vartyp, exists := t.CurrentTable.LookupVar(assign.Literal.Literal); exists && vartyp != tokenType {
+			t.err(stmt.Rhs.Token(), fmt.Sprintf(
 				"Ein Wert vom Typ %s kann keiner Variable vom Typ %s zugewiesen werden",
-				ty,
+				tokenType,
 				vartyp,
 			))
 		}
@@ -364,6 +382,7 @@ func (t *Typechecker) VisitAssignStmt(s *ast.AssignStmt) ast.Visitor {
 		if t.Evaluate(assign.Index) != token.ZAHL {
 			t.err(assign.Index.Token(), "Der STELLE Operator erwartet eine Zahl als zweiten Operanden")
 		}
+
 		lhs := t.Evaluate(assign.Name)
 		switch lhs {
 		case token.TEXT:
@@ -371,107 +390,110 @@ func (t *Typechecker) VisitAssignStmt(s *ast.AssignStmt) ast.Visitor {
 		default:
 			t.err(assign.Name.Token(), "Der STELLE Operator erwartet einen Text oder eine Liste als ersten Operanden")
 		}
-		if lhs != ty {
-			t.err(s.Rhs.Token(), fmt.Sprintf(
+
+		if lhs != tokenType {
+			t.err(stmt.Rhs.Token(), fmt.Sprintf(
 				"Ein Wert vom Typ %s kann keiner Variable vom Typ %s zugewiesen werden",
-				ty,
+				tokenType,
 				lhs,
 			))
 		}
 	}
+
 	return t
 }
-func (t *Typechecker) VisitBlockStmt(s *ast.BlockStmt) ast.Visitor {
-	t.CurrentTable = s.Symbols
-	for _, stmt := range s.Statements {
+func (t *Typechecker) VisitBlockStmt(stmt *ast.BlockStmt) ast.Visitor {
+	t.CurrentTable = stmt.Symbols
+	for _, stmt := range stmt.Statements {
 		t.visit(stmt)
 	}
-	t.CurrentTable = s.Symbols.Enclosing
+
+	t.CurrentTable = stmt.Symbols.Enclosing
 	return t
 }
-func (t *Typechecker) VisitIfStmt(s *ast.IfStmt) ast.Visitor {
-	condty := t.Evaluate(s.Condition)
-	if condty != token.BOOLEAN {
-		t.err(s.Condition.Token(), fmt.Sprintf(
+func (t *Typechecker) VisitIfStmt(stmt *ast.IfStmt) ast.Visitor {
+	conditionType := t.Evaluate(stmt.Condition)
+	if conditionType != token.BOOLEAN {
+		t.err(stmt.Condition.Token(), fmt.Sprintf(
 			"Die Bedingung einer WENN Anweisung muss vom Typ Boolean sein, war aber vom Typ %s",
-			condty,
+			conditionType,
 		))
 	}
-	t.visit(s.Then)
-	if s.Else != nil {
-		t.visit(s.Else)
+	t.visit(stmt.Then)
+	if stmt.Else != nil {
+		t.visit(stmt.Else)
 	}
 	return t
 }
-func (t *Typechecker) VisitWhileStmt(s *ast.WhileStmt) ast.Visitor {
-	condty := t.Evaluate(s.Condition)
-	switch s.While.Type {
+func (t *Typechecker) VisitWhileStmt(stmt *ast.WhileStmt) ast.Visitor {
+	conditionType := t.Evaluate(stmt.Condition)
+	switch stmt.While.Type {
 	case token.SOLANGE, token.MACHE:
-		if condty != token.BOOLEAN {
-			t.err(s.Condition.Token(), fmt.Sprintf(
+		if conditionType != token.BOOLEAN {
+			t.err(stmt.Condition.Token(), fmt.Sprintf(
 				"Die Bedingung einer SOLANGE Anweisung muss vom Typ BOOLEAN sein, war aber vom Typ %s",
-				condty,
+				conditionType,
 			))
 		}
 	case token.MAL:
-		if condty != token.ZAHL {
-			t.err(s.Condition.Token(), fmt.Sprintf(
+		if conditionType != token.ZAHL {
+			t.err(stmt.Condition.Token(), fmt.Sprintf(
 				"Die Anzahl an Wiederholungen einer WIEDERHOLE Anweisung muss vom Typ ZAHL sein, war aber vom Typ %s",
-				condty,
+				conditionType,
 			))
 		}
 	}
-	return s.Body.Accept(t)
+	return stmt.Body.Accept(t)
 }
-func (t *Typechecker) VisitForStmt(s *ast.ForStmt) ast.Visitor {
-	t.visit(s.Initializer)
-	toty := t.Evaluate(s.To)
-	if toty != token.ZAHL {
-		t.err(s.To.Token(), fmt.Sprintf(
+func (t *Typechecker) VisitForStmt(stmt *ast.ForStmt) ast.Visitor {
+	t.visit(stmt.Initializer)
+	toType := t.Evaluate(stmt.To)
+	if toType != token.ZAHL {
+		t.err(stmt.To.Token(), fmt.Sprintf(
 			"Es wurde ein Ausdruck vom Typ ZAHL erwartet aber %s gefunden",
-			toty,
+			toType,
 		))
 	}
-	if s.StepSize != nil {
-		stepty := t.Evaluate(s.StepSize)
-		if stepty != token.ZAHL {
-			t.err(s.To.Token(), fmt.Sprintf(
+	if stmt.StepSize != nil {
+		stepType := t.Evaluate(stmt.StepSize)
+		if stepType != token.ZAHL {
+			t.err(stmt.To.Token(), fmt.Sprintf(
 				"Es wurde ein Ausdruck vom Typ ZAHL erwartet aber %s gefunden",
-				stepty,
+				stepType,
 			))
 		}
 	}
-	return s.Body.Accept(t)
+	return stmt.Body.Accept(t)
 }
-func (t *Typechecker) VisitForRangeStmt(s *ast.ForRangeStmt) ast.Visitor {
-	elementType := s.Initializer.Type.Type
-	inType := t.Evaluate(s.In)
+func (t *Typechecker) VisitForRangeStmt(stmt *ast.ForRangeStmt) ast.Visitor {
+	elementType := stmt.Initializer.Type.Type
+	inType := t.Evaluate(stmt.In)
 	switch inType {
 	case token.TEXT:
 		if elementType != token.BUCHSTABE {
-			t.err(s.Initializer.Token(), fmt.Sprintf(
+			t.err(stmt.Initializer.Token(), fmt.Sprintf(
 				"Es wurde ein Ausdruck vom Typ BUCHSTABE erwartet aber %s gefunden",
 				elementType,
 			))
 		}
 	default:
-		t.err(s.Token(), fmt.Sprintf(
+		t.err(stmt.Token(), fmt.Sprintf(
 			"Es wurde ein Ausdruck vom Typ TEXT erwartet aber %s gefunden",
 			inType,
 		))
 	}
-	return s.Body.Accept(t)
+	return stmt.Body.Accept(t)
 }
-func (t *Typechecker) VisitFuncCallStmt(s *ast.FuncCallStmt) ast.Visitor {
-	return s.Call.Accept(t)
+func (t *Typechecker) VisitFuncCallStmt(stmt *ast.FuncCallStmt) ast.Visitor {
+	return stmt.Call.Accept(t)
 }
-func (t *Typechecker) VisitReturnStmt(s *ast.ReturnStmt) ast.Visitor {
-	ty := t.Evaluate(s.Value)
-	if fun, exists := t.CurrentTable.LookupFunc(s.Func); exists && fun.Type.Type != ty {
-		t.err(s.Token(), fmt.Sprintf(
+func (t *Typechecker) VisitReturnStmt(stmt *ast.ReturnStmt) ast.Visitor {
+	tokenType := t.Evaluate(stmt.Value)
+	if fun, exists := t.CurrentTable.LookupFunc(stmt.Func); exists && fun.Type.Type != tokenType {
+		t.err(stmt.Token(), fmt.Sprintf(
 			"Eine Funktion mit Rückgabetyp %s kann keinen Wert vom Typ %s zurückgeben",
 			fun.Type.Type,
-			ty,
+			tokenType,
 		))
 	}
 	return t

--- a/pkg/ast/visitor.go
+++ b/pkg/ast/visitor.go
@@ -3,9 +3,17 @@ package ast
 // interface for visiting DDP expressions, statements and declarations
 // see the Visitor pattern
 type Visitor interface {
+	/*
+		Declarations
+	*/
+
 	VisitBadDecl(*BadDecl) Visitor
 	VisitVarDecl(*VarDecl) Visitor
 	VisitFuncDecl(*FuncDecl) Visitor
+
+	/*
+		Expressions
+	*/
 
 	VisitBadExpr(*BadExpr) Visitor
 	VisitIdent(*Ident) Visitor
@@ -20,6 +28,10 @@ type Visitor interface {
 	VisitTernaryExpr(*TernaryExpr) Visitor
 	VisitGrouping(*Grouping) Visitor
 	VisitFuncCall(*FuncCall) Visitor
+
+	/*
+		Statements
+	*/
 
 	VisitBadStmt(*BadStmt) Visitor
 	VisitDeclStmt(*DeclStmt) Visitor

--- a/pkg/compiler/compiler.go
+++ b/pkg/compiler/compiler.go
@@ -124,7 +124,7 @@ func (c *Compiler) comment(comment string, block *ir.Block) {
 
 // helper to visit a single node
 func (c *Compiler) visitNode(node ast.Node) {
-	c = node.Accept(c).(*Compiler)
+	node.Accept(c)
 }
 
 // helper to evalueate an expression and return its ir value

--- a/pkg/compiler/helper.go
+++ b/pkg/compiler/helper.go
@@ -40,8 +40,8 @@ func newInt(value int64) *constant.Int {
 }
 
 // turn a tokenType into the corresponding llvm type
-func toDDPType(t token.TokenType) types.Type {
-	switch t {
+func toDDPType(tokenType token.TokenType) types.Type {
+	switch tokenType {
 	case token.NICHTS:
 		return void
 	case token.ZAHL:
@@ -55,12 +55,12 @@ func toDDPType(t token.TokenType) types.Type {
 	case token.TEXT:
 		return ddpstrptr
 	}
-	panic(fmt.Errorf("illegal ddp type to ir type conversion (%s)", t.String()))
+	panic(fmt.Errorf("illegal ddp type to ir type conversion (%s)", tokenType.String()))
 }
 
 // returns the default constant for global variables
-func getDefaultValue(t token.TokenType) constant.Constant {
-	switch t {
+func getDefaultValue(tokenType token.TokenType) constant.Constant {
+	switch tokenType {
 	case token.ZAHL:
 		return constant.NewInt(ddpint, 0)
 	case token.KOMMAZAHL:
@@ -72,5 +72,5 @@ func getDefaultValue(t token.TokenType) constant.Constant {
 	case token.TEXT:
 		return constant.NewNull(ddpstrptr)
 	}
-	panic(fmt.Errorf("illegal ddp type to ir type conversion (%s)", t.String()))
+	panic(fmt.Errorf("illegal ddp type to ir type conversion (%s)", tokenType.String()))
 }

--- a/pkg/compiler/interface.go
+++ b/pkg/compiler/interface.go
@@ -15,35 +15,42 @@ import (
 func Compile(file string, src []byte, errorHandler scanner.ErrorHandler) (string, error) {
 	var Ast *ast.Ast
 	var err error
+
 	if src != nil {
 		Ast, err = parser.ParseSource(file, src, errorHandler)
 	} else {
 		Ast, err = parser.ParseFile(file, errorHandler)
 	}
+
 	if err != nil {
 		return "", err
 	}
+
 	return New(Ast, errorHandler).Compile(nil)
 }
 
 // compile the given source or file to llvm ir
 // if src is not nil it is used, otherwise the path in file is read
 // writes the resulting llvm ir to w
-func CompileTo(file string, src []byte, errorHandler scanner.ErrorHandler, w io.Writer) error {
-	if w == nil {
+func CompileTo(file string, src []byte, errorHandler scanner.ErrorHandler, writer io.Writer) error {
+	if writer == nil {
 		return errors.New("w was nil")
 	}
+
 	var Ast *ast.Ast
 	var err error
+
 	if src != nil {
 		Ast, err = parser.ParseSource(file, src, errorHandler)
 	} else {
 		Ast, err = parser.ParseFile(file, errorHandler)
 	}
+
 	if err != nil {
 		return err
 	}
-	_, err = New(Ast, errorHandler).Compile(w)
+
+	_, err = New(Ast, errorHandler).Compile(writer)
 	return err
 }
 
@@ -53,10 +60,10 @@ func CompileAst(Ast *ast.Ast, errorHandler scanner.ErrorHandler) (string, error)
 }
 
 // compile the given AST to llvm ir
-func CompileAstTo(Ast *ast.Ast, errorHandler scanner.ErrorHandler, w io.Writer) error {
-	if w == nil {
+func CompileAstTo(Ast *ast.Ast, errorHandler scanner.ErrorHandler, writer io.Writer) error {
+	if writer == nil {
 		return errors.New("w was nil")
 	}
-	_, err := New(Ast, errorHandler).Compile(w)
+	_, err := New(Ast, errorHandler).Compile(writer)
 	return err
 }

--- a/pkg/compiler/scope.go
+++ b/pkg/compiler/scope.go
@@ -40,7 +40,7 @@ func (s *scope) lookupVar(name string) varwrapper {
 }
 
 // add a variable to the scope
-func (s *scope) addVar(name string, val value.Value, ty types.Type) value.Value {
-	s.variables[name] = varwrapper{val: val, typ: ty}
+func (scope *scope) addVar(name string, val value.Value, ty types.Type) value.Value {
+	scope.variables[name] = varwrapper{val: val, typ: ty}
 	return val
 }

--- a/pkg/interpreter/environment.go
+++ b/pkg/interpreter/environment.go
@@ -18,26 +18,26 @@ func newEnvironment(enclosing *environment) *environment {
 }
 
 // receives the value of the var name and checks if it exists or not
-func (e *environment) lookupVar(name string) (value, bool) {
-	if v, ok := e.variables[name]; !ok {
-		if e.enclosing != nil {
-			return e.enclosing.lookupVar(name)
+func (env *environment) lookupVar(name string) (value, bool) {
+	if val, ok := env.variables[name]; !ok {
+		if env.enclosing != nil {
+			return env.enclosing.lookupVar(name)
 		}
 		return nil, false // variable doesn't exist
 	} else {
-		return v, true
+		return val, true
 	}
 }
 
 // receives the function of name and checks if it exists or not
-func (e *environment) lookupFunc(name string) (*ast.FuncDecl, bool) {
-	if v, ok := e.functions[name]; !ok {
-		if e.enclosing != nil {
-			return e.enclosing.lookupFunc(name)
+func (env *environment) lookupFunc(name string) (*ast.FuncDecl, bool) {
+	if val, ok := env.functions[name]; !ok {
+		if env.enclosing != nil {
+			return env.enclosing.lookupFunc(name)
 		}
 		return nil, false
 	} else {
-		return v, true
+		return val, true
 	}
 }
 

--- a/pkg/interpreter/inbuilt_functions.go
+++ b/pkg/interpreter/inbuilt_functions.go
@@ -21,20 +21,20 @@ var inbuiltFunctions = map[string]inbuiltfunction{
 }
 
 func schreibeZahl(i *Interpreter) value {
-	v, _ := i.currentEnvironment.lookupVar("p1")
-	fmt.Fprint(i.Stdout, v.(ddpint))
+	val, _ := i.currentEnvironment.lookupVar("p1")
+	fmt.Fprint(i.Stdout, val.(ddpint))
 	return nil
 }
 
 func schreibeKommazahl(i *Interpreter) value {
-	v, _ := i.currentEnvironment.lookupVar("p1")
-	fmt.Fprint(i.Stdout, v.(ddpfloat))
+	val, _ := i.currentEnvironment.lookupVar("p1")
+	fmt.Fprint(i.Stdout, val.(ddpfloat))
 	return nil
 }
 
 func schreibeBoolean(i *Interpreter) value {
-	v, _ := i.currentEnvironment.lookupVar("p1")
-	if v.(ddpbool) {
+	val, _ := i.currentEnvironment.lookupVar("p1")
+	if val.(ddpbool) {
 		fmt.Fprint(i.Stdout, "wahr")
 	} else {
 		fmt.Fprint(i.Stdout, "falsch")
@@ -43,14 +43,14 @@ func schreibeBoolean(i *Interpreter) value {
 }
 
 func schreibeBuchstabe(i *Interpreter) value {
-	v, _ := i.currentEnvironment.lookupVar("p1")
-	fmt.Fprint(i.Stdout, string(v.(ddpchar)))
+	val, _ := i.currentEnvironment.lookupVar("p1")
+	fmt.Fprint(i.Stdout, string(val.(ddpchar)))
 	return nil
 }
 
 func schreibeText(i *Interpreter) value {
-	v, _ := i.currentEnvironment.lookupVar("p1")
-	fmt.Fprint(i.Stdout, v.(ddpstring))
+	val, _ := i.currentEnvironment.lookupVar("p1")
+	fmt.Fprint(i.Stdout, val.(ddpstring))
 	return nil
 }
 

--- a/pkg/interpreter/interface.go
+++ b/pkg/interpreter/interface.go
@@ -12,6 +12,7 @@ func InterpretFile(path string, errorHandler scanner.ErrorHandler) error {
 	if err != nil {
 		return err
 	}
+
 	return New(Ast, errorHandler).Interpret()
 }
 
@@ -21,6 +22,7 @@ func InterpretSource(name string, src []byte, errorHandler scanner.ErrorHandler)
 	if err != nil {
 		return err
 	}
+
 	return New(Ast, errorHandler).Interpret()
 }
 

--- a/pkg/interpreter/interpreter.go
+++ b/pkg/interpreter/interpreter.go
@@ -68,7 +68,7 @@ func (i *Interpreter) Interpret() (result error) {
 }
 
 func (i *Interpreter) visitNode(node ast.Node) {
-	i = node.Accept(i).(*Interpreter)
+	node.Accept(i)
 }
 
 func (i *Interpreter) VisitBadDecl(d *ast.BadDecl) ast.Visitor {
@@ -303,7 +303,7 @@ func (i *Interpreter) VisitUnaryExpr(e *ast.UnaryExpr) ast.Visitor {
 	case token.TEXT:
 		switch v := rhs.(type) {
 		case ddpint:
-			i.lastReturn = ddpstring(strconv.FormatInt(int64(v), 64))
+			i.lastReturn = ddpstring(strconv.FormatInt(int64(v), 10))
 		case ddpfloat:
 			i.lastReturn = ddpstring(strconv.FormatFloat(float64(v), 'f', -1, 64))
 		case ddpchar:

--- a/pkg/interpreter/values.go
+++ b/pkg/interpreter/values.go
@@ -14,18 +14,18 @@ type ddpbool bool
 type ddpchar rune
 type ddpstring string
 
-func (val ddpint) Type() token.TokenType {
+func (ddpint) Type() token.TokenType {
 	return token.ZAHL
 }
-func (val ddpfloat) Type() token.TokenType {
+func (ddpfloat) Type() token.TokenType {
 	return token.KOMMAZAHL
 }
-func (val ddpbool) Type() token.TokenType {
+func (ddpbool) Type() token.TokenType {
 	return token.BOOLEAN
 }
-func (val ddpchar) Type() token.TokenType {
+func (ddpchar) Type() token.TokenType {
 	return token.BUCHSTABE
 }
-func (val ddpstring) Type() token.TokenType {
+func (ddpstring) Type() token.TokenType {
 	return token.TEXT
 }

--- a/pkg/interpreter/values.go
+++ b/pkg/interpreter/values.go
@@ -14,18 +14,18 @@ type ddpbool bool
 type ddpchar rune
 type ddpstring string
 
-func (v ddpint) Type() token.TokenType {
+func (val ddpint) Type() token.TokenType {
 	return token.ZAHL
 }
-func (v ddpfloat) Type() token.TokenType {
+func (val ddpfloat) Type() token.TokenType {
 	return token.KOMMAZAHL
 }
-func (v ddpbool) Type() token.TokenType {
+func (val ddpbool) Type() token.TokenType {
 	return token.BOOLEAN
 }
-func (v ddpchar) Type() token.TokenType {
+func (val ddpchar) Type() token.TokenType {
 	return token.BUCHSTABE
 }
-func (v ddpstring) Type() token.TokenType {
+func (val ddpstring) Type() token.TokenType {
 	return token.TEXT
 }

--- a/pkg/parser/interface.go
+++ b/pkg/parser/interface.go
@@ -12,6 +12,7 @@ func ParseFile(path string, errorHandler scanner.ErrorHandler) (*ast.Ast, error)
 	if err != nil {
 		return nil, err
 	}
+
 	return New(file, errorHandler).Parse(), nil
 }
 
@@ -22,6 +23,7 @@ func ParseSource(name string, src []byte, errorHandler scanner.ErrorHandler) (*a
 	if err != nil {
 		return nil, err
 	}
+
 	return New(file, errorHandler).Parse(), nil
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -63,7 +63,7 @@ func init() {
 					return err
 				}
 
-				p := New(tokens, Err) // create the p for this file
+				p := New(tokens, Err) // create the parser for this file
 				Ast := p.Parse()      // parse the file
 				if Ast.Faulty {
 					Err(errTok, err.Error())
@@ -107,7 +107,7 @@ type Parser struct {
 	funcAliases     []funcAlias              // all found aliases (+ inbuild aliases)
 	currentFunction string                   // function which is currently being parsed
 	panicMode       bool                     // flag to not report following errors
-	Errored         bool                     // wether the p found an error
+	Errored         bool                     // wether the parser found an error
 	resolver        *resolver.Resolver       // used to resolve every node directly after it has been parsed
 	typechecker     *typechecker.Typechecker // used to typecheck every node directly after it has been parsed
 }
@@ -307,7 +307,7 @@ func (p *Parser) varDeclaration() ast.Declaration {
 }
 
 func (p *Parser) funcDeclaration() ast.Declaration {
-	valid := true              // checks if the function is valid and may be appended to the p state as p.errored = !valid
+	valid := true              // checks if the function is valid and may be appended to the parser state as p.errored = !valid
 	validate := func(b bool) { // helper for setting the valid flag (to simplify some big boolean expressions)
 		if !b {
 			valid = false
@@ -1617,7 +1617,7 @@ outer:
 				copy(tokens, p.tokens[exprStart:p.cur]) // copy all the tokens of the expression to be able to append the EOF
 				// append the EOF needed for the parser
 				tokens = append(tokens, token.Token{Type: token.EOF, Literal: "", Indent: 0, File: tok.File, Line: tok.Line, Column: tok.Column, AliasInfo: nil})
-				argParser := New(tokens, p.errorHandler) // create a new p for this expression
+				argParser := New(tokens, p.errorHandler) // create a new parser for this expression
 				argParser.funcAliases = p.funcAliases    // it needs the functions aliases
 				arg := argParser.expression()            // parse the argument
 

--- a/pkg/scanner/scanner.go
+++ b/pkg/scanner/scanner.go
@@ -87,11 +87,7 @@ func New(filePath string, src []byte, errorHandler ErrorHandler, mode Mode) (*Sc
 		return nil, errors.New("invalid utf8 source")
 	}
 
-	scan.src = make([]rune, 0, utf8.RuneCount(src))
-	str := string(src)
-	for _, r := range str {
-		scan.src = append(scan.src, r)
-	}
+	scan.src = []rune(string(src))
 
 	return scan, nil
 }

--- a/tests/kddp_test.go
+++ b/tests/kddp_test.go
@@ -14,9 +14,11 @@ func TestKDDP(t *testing.T) {
 			t.Logf("Error walking %s: %s\nskipping this directory", path, err)
 			return fs.SkipDir
 		}
+
 		if !d.IsDir() {
 			return nil
 		}
+
 		if d.Name() == "testdata" {
 			return nil
 		}
@@ -28,6 +30,7 @@ func TestKDDP(t *testing.T) {
 				t.Errorf("Could not read expected output: %s", err.Error())
 				return
 			}
+
 			filename := filepath.Join(path, filepath.Base(path)) + ".ddp"
 			cmd := exec.Command("../build/kddp", "build", changeExtension(filename, ".ddp"), "-o", changeExtension(filename, ".exe"), "--verbose")
 			if out, err := cmd.CombinedOutput(); err != nil {
@@ -44,9 +47,11 @@ func TestKDDP(t *testing.T) {
 				if out, err := cmd.CombinedOutput(); err != nil {
 					t.Logf("cannot getcombined out when recompiling: %s\nout:\n%s", err, out)
 				}
+
 				t.Errorf("\nerror getting combined output: %s\noutput:\n%s", err, out)
 				return
 			}
+
 			if out, expected := string(out), string(expected); out != expected {
 				t.Errorf("Test did not yield the expected output\nExpected:\n%s\nGot:\n%s", expected, out)
 				return


### PR DESCRIPTION
changed a lot of variable names to more descriptive ones.

For example:
* ty => tokenType
* d => decl
* e => expr
* s => stmt
* ch => char

I also added whitespace in some places to physically seperate logic blocks. This helps make the code more readable at a glance.