### PR TITLE
Bessere Fehlerberichte

### DIFF
--- a/src/ast/typechecker/typechecker.go
+++ b/src/ast/typechecker/typechecker.go
@@ -119,9 +119,10 @@ func (t *Typechecker) VisitVarDecl(decl *ast.VarDecl) ast.VisitResult {
 	return ast.VisitRecurse
 }
 func (t *Typechecker) VisitFuncDecl(decl *ast.FuncDecl) ast.VisitResult {
-	if !ast.IsExternFunc(decl) {
+	// already typechecked in blockStmt
+	/*if !ast.IsExternFunc(decl) {
 		decl.Body.Accept(t)
-	}
+	}*/
 
 	// TODO: error on the type-name ranges
 	if decl.IsPublic {

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -102,8 +102,13 @@ func newParser(name string, tokens []token.Token, modules map[string]*ast.Module
 	}
 
 	// prepare the resolver and typechecker with the inbuild symbols and types
-	parser.resolver = resolver.New(parser.module, parser.errorHandler, name)
-	parser.typechecker = typechecker.New(parser.module, parser.errorHandler, name)
+	var err error
+	if parser.resolver, err = resolver.New(parser.module, parser.errorHandler, name, &parser.panicMode); err != nil {
+		panic(err)
+	}
+	if parser.typechecker, err = typechecker.New(parser.module, parser.errorHandler, name, &parser.panicMode); err != nil {
+		panic(err)
+	}
 
 	return parser
 }

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -153,9 +153,7 @@ func (s *Scanner) NextToken() token.Token {
 		}
 	}
 
-	msg := fmt.Sprintf("Unerwartetes Zeichen '%s'", string(char))
-	s.err(ddperror.SYN_UNEXPECTED_TOKEN, s.currentRange(), msg)
-	return s.errorToken(msg)
+	return s.errorToken(fmt.Sprintf("Unerwartetes Zeichen '%s'", string(char)))
 }
 
 func (s *Scanner) scanEscape(quote rune) bool {
@@ -195,9 +193,7 @@ func (s *Scanner) string() token.Token {
 	}
 
 	if s.atEnd() {
-		msg := "ein Offenes Text Literal"
-		s.err(ddperror.SYN_MALFORMED_LITERAL, s.currentRange(), msg)
-		return s.errorToken(msg)
+		return s.errorToken("ein Offenes Text Literal")
 	}
 
 	s.advance()
@@ -219,9 +215,7 @@ func (s *Scanner) char() token.Token {
 	}
 
 	if s.atEnd() {
-		msg := "ein Offenes Buchstaben Literal"
-		s.err(ddperror.SYN_MALFORMED_LITERAL, s.currentRange(), msg)
-		return s.errorToken(msg)
+		return s.errorToken("ein Offenes Buchstaben Literal")
 	}
 
 	s.advance()


### PR DESCRIPTION
Deutliche Verbesserung von Fehlermeldungen.

Vorher wurden sehr oft Fehler doppelt gemeldet, oder es wurden Typfehler gemeldet, die durch einen vorangehenden syntax Fehler entstanden sind.
Das passiert jetzt deutlich seltener.

Auch der nervige Fehler "Die Anzahl an Wiederholungen einer WIEDERHOLE Anweisung muss vom Typ ZAHL sein, war aber vom Typ nichts" sollte nicht mehr vorkommen wenn man einen . vergessen hat, sondern nur wenn es Sinn macht.