### PR TITLE
Bug-fixes und Fehlermeldungen in Duden/Dateisystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung (v1.0.0-alpha)
 
+- [Fix] Erstelle_Ordner gibt keinen Fehler mehr zurück, wenn einer der Ordner bereits existiert
 - [Fix] `kddp update` ignoriert die -jetzt flag nicht mehr
 - [Fix] `kddp update` updated jetzt auch den Duden
 - [Added] Datei_Kopieren Funktion zu Duden/Dateisystem 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ CMAKE = cmake
 SHELL = /bin/bash
 .SHELLFLAGS = -o pipefail -c
 
-.PHONY = all clean clean-outdir debug kddp stdlib stdlib-debug runtime runtime-debug test test-memory download-llvm llvm help test-complete
+.PHONY = all clean clean-outdir debug kddp duden stdlib stdlib-debug runtime runtime-debug test test-memory download-llvm llvm help test-complete
 
 all: $(OUT_DIR) kddp runtime stdlib
 
@@ -69,22 +69,24 @@ kddp:
 	$(CP) $(KDDP_DIR)build/$(KDDP_BIN) $(KDDP_DIR_OUT)$(KDDP_BIN)
 	$(KDDP_DIR_OUT)$(KDDP_BIN) dump-list-defs -o $(LIB_DIR_OUT)$(DDP_LIST_DEFS_NAME) $(DDP_LIST_DEFS_OUTPUT_TYPES)
 
-stdlib:
+duden:
+	@echo "copying duden"
+	$(CP) $(STD_DIR)Duden/ $(OUT_DIR)
+
+stdlib: duden
 	@echo "building the ddp-stdlib"
 	cd $(STD_DIR) ; '$(MAKE)'
 	$(CP) $(STD_DIR)$(STD_BIN) $(LIB_DIR_OUT)$(STD_BIN)
 	$(CP) $(STD_DIR)include/ $(STD_DIR_OUT)
 	$(CP) $(STD_DIR)source/ $(STD_DIR_OUT)
-	$(CP) $(STD_DIR)Duden/ $(OUT_DIR)
 	$(CP) $(STD_DIR)Makefile $(STD_DIR_OUT)Makefile
 
-stdlib-debug:
+stdlib-debug: duden
 	@echo "building the ddp-stdlib in debug mode"
 	cd $(STD_DIR) ; '$(MAKE)' debug
 	$(CP) $(STD_DIR)$(STD_BIN_DEBUG) $(LIB_DIR_OUT)$(STD_BIN)
 	$(CP) $(STD_DIR)include/ $(STD_DIR_OUT)
 	$(CP) $(STD_DIR)source/ $(STD_DIR_OUT)
-	$(CP) $(STD_DIR)Duden/ $(OUT_DIR)
 	$(CP) $(STD_DIR)Makefile $(STD_DIR_OUT)Makefile
 
 runtime:

--- a/lib/stdlib/Duden/Dateisystem.ddp
+++ b/lib/stdlib/Duden/Dateisystem.ddp
@@ -31,7 +31,8 @@ und kann so benutzt werden:
 	"der Pfad <Pfad> existiert"
 
 [
-	Überprüft ob der gegebene Pfad ein Ordner ist
+	Überprüft ob der gegebene Pfad ein Ordner ist.
+	Im Falle eines Fehlers wird falsch zurückgegeben.
 ]
 Die öffentliche Funktion Ist_Ordner mit dem Parameter Pfad vom Typ Text, gibt einen Wahrheitswert zurück,
 ist in "libddpstdlib.a" definiert
@@ -53,11 +54,11 @@ Und kann so benutzt werden:
 
 	Gibt zurück ob das Erstellen erfolgreich war.
 ]
-Die öffentliche Funktion Erstelle_Ordner mit dem Parameter Pfad vom Typ Text, gibt einen Wahrheitswert zurück,
+Die öffentliche Funktion Erstelle_Ordner mit den Parametern Pfad und Fehler vom Typ Text und Text Referenz, gibt einen Wahrheitswert zurück,
 ist in "libddpstdlib.a" definiert
 und kann so benutzt werden:
-	"Erstelle den Ordner <Pfad>" oder
-	"der Ordner <Pfad> erfolgreich erstellt wurde"
+	"Erstelle den Ordner <Pfad> mit Fehler <Fehler>" oder
+	"der Ordner <Pfad> erfolgreich mit Fehler <Fehler> erstellt wurde"
 
 [
 	!!!Nicht unbedingt sicher!!!
@@ -66,16 +67,17 @@ und kann so benutzt werden:
 	Im Falle eines Ordners wird rekursiv das gesamte Verzeichnis gelöscht.
 
 	Gibt zurück ob das Löschen erfolgreich war.
+	Im Falle eines Fehlers wird dieser in Fehler gespeichert.
 ]
-Die öffentliche Funktion Loesche_Pfad mit dem Parameter Pfad vom Typ Text, gibt einen Wahrheitswert zurück,
+Die öffentliche Funktion Loesche_Pfad mit den Parametern Pfad und Fehler vom Typ Text und Text Referenz, gibt einen Wahrheitswert zurück,
 ist in "libddpstdlib.a" definiert
 und kann so benutzt werden:
-	"Lösche <Pfad>" oder
-	"<Pfad> erfolgreich gelöscht wurde" oder
-	"Lösche die Datei <Pfad>" oder
-	"die Datei <Pfad> erfolgreich gelöscht wurde" oder
-	"Lösche den Ordner <Pfad>" oder
-	"der Ordner <Pfad> erfolgreich gelöscht wurde"
+	"Lösche <Pfad> mit Fehler <Fehler>" oder
+	"<Pfad> erfolgreich mit Fehler <Fehler> gelöscht wurde" oder
+	"Lösche die Datei <Pfad> mit Fehler <Fehler>" oder
+	"die Datei <Pfad> erfolgreich mit Fehler <Fehler> gelöscht wurde" oder
+	"Lösche den Ordner <Pfad> mit Fehler <Fehler>" oder
+	"der Ordner <Pfad> erfolgreich mit Fehler <Fehler> gelöscht wurde"
 
 [
 	!!!Nicht unbedings sicher!!!
@@ -85,11 +87,11 @@ und kann so benutzt werden:
 
 	Gibt zurück ob das Umbenennen erfolgreich war.
 ]
-Die öffentliche Funktion Pfad_Verschieben mit den Parametern Pfad und NeuerName vom Typ Text und Text, gibt einen Wahrheitswert zurück,
+Die öffentliche Funktion Pfad_Verschieben mit den Parametern Pfad, NeuerName und Fehler vom Typ Text, Text und Text Referenz, gibt einen Wahrheitswert zurück,
 ist in "libddpstdlib.a" definiert
 und kann so benutzt werden:
-	"Verschiebe <Pfad> nach <NeuerName>" oder
-	"<Pfad> erfolgreich nach <NeuerName> verschoben wurde"
+	"Verschiebe <Pfad> nach <NeuerName> mit Fehler <Fehler>" oder
+	"<Pfad> erfolgreich mit Fehler <Fehler> nach <NeuerName> verschoben wurde"
 
 [
 	Equavilent zu C's stat.st_atime formatiert als Text
@@ -133,9 +135,13 @@ Und kann so benutzt werden:
 	"den Modus der Datei <Pfad>"
 
 [
-	Kopiert die Datei am Pfad nach Kopiepfad. !! Achtung: Kann existierende Dateien überschreiben !!
+	!! Achtung: Kann existierende Dateien überschreiben !!
+
+	Kopiert die Datei am Pfad nach Kopiepfad.
+	Ein möglicher Fehler wird in Fehler gespeichert.
 ]
-Die öffentliche Funktion Datei_Kopieren mit den Parametern Pfad und Kopiepfad vom Typ Text und Text, gibt einen Wahrheitswert zurück,
+Die öffentliche Funktion Datei_Kopieren mit den Parametern Pfad, Kopiepfad und Fehler vom Typ Text, Text und Text Referenz, gibt einen Wahrheitswert zurück,
 ist in "libddpstdlib.a" definiert
 Und kann so benutzt werden:
-	"Kopiere die Datei <Pfad> nach <Kopiepfad>"
+	"Kopiere die Datei <Pfad> nach <Kopiepfad> mit Fehler <Fehler>" oder
+	"die Datei <Pfad> erfolgreich mit Fehler <Fehler> nach <Kopiepfad> kopiert wurde"

--- a/lib/stdlib/source/io.c
+++ b/lib/stdlib/source/io.c
@@ -10,7 +10,6 @@
 #include "ddpmemory.h"
 #include "debug.h"
 #include <math.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <string.h>
 #include "ddpwindows.h"
@@ -110,66 +109,4 @@ ddpchar extern_lies_buchstabe(ddpboolref war_eof) {
 #ifdef DDPOS_WINDOWS
 	}
 #endif // DDPOS_WINDOWS
-}
-
-/*
-	File IO
-*/
-
-static void write_error(ddpstringref ref, const char* fmt, ...) {
-	char errbuff[1024];
-
-	va_list argptr;
-	va_start(argptr, fmt);
-
-	int len = vsprintf(errbuff, fmt, argptr);
-	
-	va_end(argptr);
-
-	ref->str = ddp_reallocate(ref->str, ref->cap, len+1);
-	memcpy(ref->str, errbuff, len);
-	ref->cap = len+1;
-	ref->str[ref->cap-1] = '\0';
-}
-
-ddpint Lies_Text_Datei(ddpstring* Pfad, ddpstringref ref) {
-	FILE* file = fopen(Pfad->str, "r");
-	ddpint ret = -1;
-	if (file) {
-		fseek(file, 0, SEEK_END); // seek the last byte in the file
-		size_t string_size = ftell(file) + 1; // file_size + '\0'
-		rewind(file); // go back to file start
-		ref->str = ddp_reallocate(ref->str, ref->cap, string_size);
-		ref->cap = string_size;
-		size_t read = fread(ref->str, sizeof(char), string_size-1, file);
-		ref->str[ref->cap-1] = '\0';
-		if (read != string_size-1) {
-			ret = -1;
-			write_error(ref, "Fehler beim Lesen von '%s': %s", Pfad->str, strerror(errno));
-		} else {
-			ret = read;
-		}
-		fclose(file);
-	} else {
-		ret = -1;
-		write_error(ref, "Fehler beim Lesen von '%s': %s", Pfad->str, strerror(errno));
-	}
-
-	return ret;
-}
-
-ddpint Schreibe_Text_Datei(ddpstring* Pfad, ddpstring* text, ddpstringref fehler) {
-	FILE* file = fopen(Pfad->str, "w");
-	ddpint ret = -1;
-	if (file) {
-		ret = fprintf(file, text->str);
-		fclose(file);
-		if (ret < 0) {
-			ret = -1;
-			write_error(fehler, "Fehler beim Schreiben zu '%s': %s", Pfad->str, strerror(errno));
-		}
-	} else {
-		write_error(fehler, "Fehler beim Schreiben zu '%s': %s", Pfad->str, strerror(errno));
-	}
-	return ret;
 }


### PR DESCRIPTION
Viele der Duden/Dateisystem Funktionen haben keine Fehlermeldungen zurückgegeben. Das ist jetzt anders.

Die branch ist noch nicht 100% fertig, aber ich erstelle die Pull Request um auf ein paar Sachen hinzuweisen:

- die Funktionen die nur `stat` wrappen geben noch keinen Fehler zurück. Sollten diese eine Fehlermeldung oder einen Standardwert zurückgeben?
- Bei den meisten Funktionen muss man jetzt eine Fehler Referenz angeben, was manchmal sehr hässlich ist.
Es gibt 2 Wege das zu ändern:
1. Die Funktionen geben anstatt einem Wahrheitswert eine Fehlermeldung zurück, und ein leerer Text (`""`) steht für keinen Fehler.
Das wäre nicht schlecht, aber unpraktisch für `Wenn` Anweisungen, da man dann immer `gleich ""` überprüfen muss, wenn einem der Fehler selbst egal ist.
2. Wir schreiben wrapper-funktionen, die einfach die entsprechenden Funktionen aufrufen, aber den Fehler ignorieren und einfach nur einen Wahrheitswert zurückgeben.