### PR TITLE
Mehr Symbole in Aliasen erlauben

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung (v1.0.0-alpha)
 
+- [Added]: Beliebige utf-8 Symbole sind jetzt in Aliasen erlaubt
 - [Breaking] `Boolean` zu `Wahrheitswert` umbennant
 - [Fix] `kddp update` ignoriert die -jetzt flag nicht mehr
 - [Fix] `kddp update` updated jetzt auch den Duden

--- a/src/ddperror/codes.go
+++ b/src/ddperror/codes.go
@@ -33,6 +33,7 @@ const (
 	SEM_ALIAS_ALREADY_TAKEN                               // the alias already stands for another function
 	SEM_ALIAS_ALREADY_DEFINED                             // the alias already stands for a different function
 	SEM_ALIAS_MUST_BE_GLOBAL                              // a non-global alias declaration was found
+	SEM_ALIAS_BAD_NUM_ARGS                                // invalid number of arguments (too many or too few)
 	SEM_GLOBAL_RETURN                                     // a return statement outside a function was found
 	SEM_BAD_NAME_CONTEXT                                  // a function name was used in place of a variable name or vice versa
 	SEM_NON_GLOBAL_PUBLIC_DECL                            // a non-global variable was declared public

--- a/src/scanner/scanner.go
+++ b/src/scanner/scanner.go
@@ -153,7 +153,7 @@ func (s *Scanner) NextToken() token.Token {
 		}
 	}
 
-	return s.errorToken(fmt.Sprintf("Unerwartetes Zeichen '%s'", string(char)))
+	return s.newToken(token.SYMBOL)
 }
 
 func (s *Scanner) scanEscape(quote rune) bool {

--- a/src/token/token_types.go
+++ b/src/token/token_types.go
@@ -6,6 +6,7 @@ const (
 	IDENTIFIER
 	ALIAS_PARAMETER // <x> only found in function aliases
 	COMMENT         // [...]
+	SYMBOL          // any symbol not matched otherwise (?, !, ~, ...)
 
 	INT    // 1 2
 	FLOAT  // 2,2 3,4
@@ -148,6 +149,7 @@ var tokenStrings = [...]string{
 	IDENTIFIER:      "ein Name",
 	ALIAS_PARAMETER: "ein Alias Parameter",
 	COMMENT:         "ein Kommentar",
+	SYMBOL:          "ein Symbol",
 
 	INT:    "eine Zahl",
 	FLOAT:  "eine Kommazahl",


### PR DESCRIPTION
In Aliasen sind jetzt beliebige Symbole erlaubt (+, !, ?, was auch immer valides utf-8 ist).
Das kann für bessere Aliase benutzt werden (und sollte natürlich nicht ausgenutzt werden, also kein + Operator).

Außerdem sollten Fehlermeldungen in Aliasen jetzt etwas detaillierter sein.