### PR TITLE
Beispiele in den Tests Kompilieren

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ endif
 TEST_DIRS = 
 
 test:
-	go test -v ./tests '-run=(TestKDDP|TestStdlib)' -test_dirs="$(TEST_DIRS)" | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''
+	go test -v ./tests '-run=(TestKDDP|TestStdlib|TestBuildExamples)' -test_dirs="$(TEST_DIRS)" | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''
 
 test-memory:
 	go test -v ./tests '-run=(TestMemory)' -test_dirs="$(TEST_DIRS)" | sed ''/PASS/s//$$(printf "\033[32mPASS\033[0m")/'' | sed ''/FAIL/s//$$(printf "\033[31mFAIL\033[0m")/''


### PR DESCRIPTION
Die Beispiele im examples/ Ordner werden jetzt als Teil der Tests kompiliert.
Das stellt sicher, dass Änderungen an der Sprache oder dem Duden die Beispiele nicht invalide machen. Das ist wichtig, da die Beispiele eine der ersten Programme sind, die jemand der DDP ausprobieren möchte kompilieren wird.

Außerdem werden die Beispiele auch im Spielplatz verwendet.