### PR TITLE
Name mangling (Issue #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung
 
+- [Added] Syntax um Variablen und Funktionen als "extern sichtbar" zu markieren, und somit name-mangling für diese auszuschalten
+- [Fix] Linker Fehler bei mehreren öffentlichen Symbolen mit demselben Namen
 - [Added] Falls Operator. Funktioniert so wie der Ternary Conditional Operator (?:) in anderen Sprachen. 
 - [Added] in Duden/Dateisystem:
     - Datei Kombination

--- a/lib/stdlib/Duden/Fehlerbehandlung.ddp
+++ b/lib/stdlib/Duden/Fehlerbehandlung.ddp
@@ -31,7 +31,7 @@ Die Zahl SchreibeFehlerFlag ist 1 um 1 Bit nach Links verschoben.
 [
 	Meldet ob es einen Fehler gab
 ]
-Die öffentliche Funktion Gab_Fehler gibt einen Wahrheitswert zurück, macht:
+Die öffentliche Funktion Gab_Fehler gibt einen Wahrheitswert zurück, ist extern sichtbar, macht:
 	Gib Fehlermeldung_Valide zurück.
 Und kann so benutzt werden:
 	"es einen Fehler gab" oder
@@ -41,7 +41,7 @@ Und kann so benutzt werden:
 	Löscht den letzten Fehler
 	Gab_Fehler gibt danach falsch zurück
 ]
-Die öffentliche Funktion Loesche_Fehler gibt nichts zurück, macht:
+Die öffentliche Funktion Loesche_Fehler gibt nichts zurück, ist extern sichtbar, macht:
 	Speichere falsch in Fehlermeldung_Valide.
 Und kann so benutzt werden:
 	"Lösche den letzten Fehler" oder
@@ -51,7 +51,7 @@ Und kann so benutzt werden:
 	Wenn es einen Fehler gab, wird dieser zurückgegeben und gelöscht
 	Ansonsten wird "" zurückgegeben
 ]
-Die öffentliche Funktion Letzter_Fehler gibt einen Text zurück, macht:
+Die öffentliche Funktion Letzter_Fehler gibt einen Text zurück, ist extern sichtbar, macht:
 	Wenn Fehlermeldung_Valide, dann:
 		Lösche den letzten Fehler.
 		Gib Fehlermeldung zurück.
@@ -103,7 +103,7 @@ Und kann so benutzt werden:
 
 	Standardmäßig wird nur der letzte Fehler gesetzt
 ]
-Die öffentliche Funktion Setze_Fehler mit dem Parameter Fehler vom Typ Text, gibt nichts zurück, macht:
+Die öffentliche Funktion Setze_Fehler mit dem Parameter Fehler vom Typ Text, gibt nichts zurück, ist extern sichtbar, macht:
 	Speichere Fehler in Fehlermeldung.
 	Speichere wahr in Fehlermeldung_Valide.
 

--- a/src/ast/declarations.go
+++ b/src/ast/declarations.go
@@ -25,17 +25,18 @@ type (
 	}
 
 	FuncDecl struct {
-		Range      token.Range
-		CommentTok *token.Token    // optional comment (also contained in ast.Comments)
-		Tok        token.Token     // Die
-		NameTok    token.Token     // token of the name
-		IsPublic   bool            // wether the function is marked with öffentliche
-		Mod        *Module         // the module in which the function was declared
-		Parameters []ParameterInfo // name, type and comments of parameters
-		Type       ddptypes.Type   // return Type, Zahl Kommazahl nichts ...
-		Body       *BlockStmt      // nil for extern functions
-		ExternFile token.Token     // string literal with filepath (only pesent if Body is nil)
-		Aliases    []*FuncAlias
+		Range           token.Range
+		CommentTok      *token.Token    // optional comment (also contained in ast.Comments)
+		Tok             token.Token     // Die
+		NameTok         token.Token     // token of the name
+		IsPublic        bool            // wether the function is marked with öffentliche
+		IsExternVisible bool            // wether the function is marked as extern visible
+		Mod             *Module         // the module in which the function was declared
+		Parameters      []ParameterInfo // name, type and comments of parameters
+		Type            ddptypes.Type   // return Type, Zahl Kommazahl nichts ...
+		Body            *BlockStmt      // nil for extern functions
+		ExternFile      token.Token     // string literal with filepath (only pesent if Body is nil)
+		Aliases         []*FuncAlias
 	}
 
 	StructDecl struct {

--- a/src/ast/declarations.go
+++ b/src/ast/declarations.go
@@ -15,13 +15,14 @@ type (
 	}
 
 	VarDecl struct {
-		Range      token.Range
-		CommentTok *token.Token  // optional comment (also contained in ast.Comments)
-		Type       ddptypes.Type // type of the variable
-		NameTok    token.Token   // identifier name
-		IsPublic   bool          // wether the function is marked with öffentliche
-		Mod        *Module       // the module in which the variable was declared
-		InitVal    Expression    // initial value
+		Range           token.Range
+		CommentTok      *token.Token  // optional comment (also contained in ast.Comments)
+		Type            ddptypes.Type // type of the variable
+		NameTok         token.Token   // identifier name
+		IsPublic        bool          // wether the function is marked with öffentliche
+		IsExternVisible bool          // wether the variable is marked as extern visible
+		Mod             *Module       // the module in which the variable was declared
+		InitVal         Expression    // initial value
 	}
 
 	FuncDecl struct {

--- a/src/ast/printer.go
+++ b/src/ast/printer.go
@@ -86,7 +86,10 @@ func (pr *printer) VisitVarDecl(decl *VarDecl) VisitResult {
 func (pr *printer) VisitFuncDecl(decl *FuncDecl) VisitResult {
 	msg := fmt.Sprintf("FuncDecl[%s: %v, %s]", decl.Name(), decl.Parameters, decl.Type)
 	if IsExternFunc(decl) {
-		msg += " Extern"
+		msg += " [Extern]"
+	}
+	if decl.IsExternVisible {
+		msg += " [Extern Visible]"
 	}
 	if decl.CommentTok != nil {
 		msg += fmt.Sprintf(commentFmt, strings.Trim(decl.CommentTok.Literal, commentCutset), pr.currentIdent, " ")

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -191,7 +191,7 @@ func (c *compiler) compile(w io.Writer, isMainModule bool) (result *Result, rerr
 		c.scp = c.exitScope(c.scp) // exit the main scope
 		// call all the module_dispose functions
 		for mod := range c.importedModules {
-			_, dispose_name := c.getModuleInitDisposeName(mod)
+			_, dispose_name := getModuleInitDisposeName(mod)
 			dispose_fun := c.functions[dispose_name]
 			c.cbb.NewCall(dispose_fun.irFunc)
 		}
@@ -331,7 +331,7 @@ func (c *compiler) setupListTypes(declarationOnly bool) {
 // used in setup()
 // creates a function that can be called to initialize the global state of this module
 func (c *compiler) setupModuleInitDispose() {
-	init_name, dispose_name := c.getModuleInitDisposeName(c.ddpModule)
+	init_name, dispose_name := getModuleInitDisposeName(c.ddpModule)
 	c.moduleInitFunc = c.mod.NewFunc(init_name, c.void.IrType())
 	c.moduleInitFunc.Visibility = enum.VisibilityDefault
 	c.moduleInitCbb = c.moduleInitFunc.NewBlock("")
@@ -440,7 +440,9 @@ func (c *compiler) VisitVarDecl(d *ast.VarDecl) ast.VisitResult {
 	if c.scp.enclosing == nil { // global scope
 		// globals are first assigned in ddp_main or module_init
 		// so we assign them a default value here
-		globalDef := c.mod.NewGlobalDef(d.Name(), Typ.DefaultValue())
+		//
+		// names are mangled only in the actual ir-definitions, not in the compiler data-structures
+		globalDef := c.mod.NewGlobalDef(c.mangledName(d), Typ.DefaultValue())
 		// make private variables static like in C
 		if !d.IsPublic {
 			globalDef.Linkage = enum.LinkageInternal
@@ -504,10 +506,10 @@ func (c *compiler) VisitFuncDecl(decl *ast.FuncDecl) ast.VisitResult {
 		params = append(params, ir.NewParam(param.Name.Literal, ty)) // add it to the list
 	}
 
-	irFunc := c.mod.NewFunc(decl.Name(), retTypeIr, params...) // create the ir function
-	irFunc.CallingConv = enum.CallingConvC                     // every function is called with the c calling convention to make interaction with inbuilt stuff easier
+	irFunc := c.mod.NewFunc(c.mangledName(decl), retTypeIr, params...) // create the ir function
+	irFunc.CallingConv = enum.CallingConvC                             // every function is called with the c calling convention to make interaction with inbuilt stuff easier
 	// make private functions static like in C
-	if !decl.IsPublic {
+	if !decl.IsPublic && !decl.IsExternVisible {
 		irFunc.Linkage = enum.LinkageInternal
 		irFunc.Visibility = enum.VisibilityDefault
 	}
@@ -1738,7 +1740,7 @@ func (c *compiler) VisitImportStmt(s *ast.ImportStmt) ast.VisitResult {
 		switch decl := decl.(type) {
 		case *ast.VarDecl: // declare the variable as external
 			Typ := c.toIrType(decl.Type)
-			globalDecl := c.mod.NewGlobal(decl.Name(), Typ.IrType())
+			globalDecl := c.mod.NewGlobal(c.mangledName(decl), Typ.IrType())
 			globalDecl.Linkage = enum.LinkageExternal
 			globalDecl.Visibility = enum.VisibilityDefault
 			c.scp.addProtected(decl.Name(), globalDecl, Typ, false) // freed by module_dispose
@@ -1760,8 +1762,8 @@ func (c *compiler) VisitImportStmt(s *ast.ImportStmt) ast.VisitResult {
 				params = append(params, ir.NewParam(param.Name.Literal, ty)) // add it to the list
 			}
 
-			irFunc := c.mod.NewFunc(decl.Name(), retTypeIr, params...) // create the ir function
-			irFunc.CallingConv = enum.CallingConvC                     // every function is called with the c calling convention to make interaction with inbuilt stuff easier
+			irFunc := c.mod.NewFunc(c.mangledName(decl), retTypeIr, params...) // create the ir function
+			irFunc.CallingConv = enum.CallingConvC                             // every function is called with the c calling convention to make interaction with inbuilt stuff easier
 			// declare it as extern function
 			irFunc.Linkage = enum.LinkageExternal
 			irFunc.Visibility = enum.VisibilityDefault
@@ -1780,7 +1782,7 @@ func (c *compiler) VisitImportStmt(s *ast.ImportStmt) ast.VisitResult {
 	// and also initialize the modules that this module imports
 	ast.IterateModuleImports(s.Module, func(module *ast.Module) {
 		if _, alreadyImported := c.importedModules[module]; !alreadyImported {
-			init_name, dispose_name := c.getModuleInitDisposeName(module)
+			init_name, dispose_name := getModuleInitDisposeName(module)
 			module_init := c.mod.NewFunc(init_name, c.void.IrType())
 			module_init.Linkage = enum.LinkageExternal
 			module_init.Visibility = enum.VisibilityDefault

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -444,7 +444,7 @@ func (c *compiler) VisitVarDecl(d *ast.VarDecl) ast.VisitResult {
 		// names are mangled only in the actual ir-definitions, not in the compiler data-structures
 		globalDef := c.mod.NewGlobalDef(c.mangledName(d), Typ.DefaultValue())
 		// make private variables static like in C
-		if !d.IsPublic {
+		if !d.IsPublic && !d.IsExternVisible {
 			globalDef.Linkage = enum.LinkageInternal
 		}
 		globalDef.Visibility = enum.VisibilityDefault

--- a/src/compiler/helper.go
+++ b/src/compiler/helper.go
@@ -154,7 +154,9 @@ func (c *compiler) mangledName(decl ast.Declaration) string {
 			return decl.Name()
 		}
 	case *ast.VarDecl:
-		// do nothing
+		if decl.IsExternVisible {
+			return decl.Name()
+		}
 	default:
 		return decl.Name()
 	}

--- a/src/compiler/helper.go
+++ b/src/compiler/helper.go
@@ -1,8 +1,11 @@
 package compiler
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/DDP-Projekt/Kompilierer/src/ast"
 	"github.com/DDP-Projekt/Kompilierer/src/ddptypes"
@@ -111,9 +114,8 @@ func (c *compiler) getListType(ty ddpIrType) *ddpIrListType {
 	return nil // unreachable
 }
 
-// creates the name of the module_init function
-func (c *compiler) getModuleInitDisposeName(mod *ast.Module) (string, string) {
-	name := "ddp_" + strings.TrimSuffix(
+func getHashableModuleName(mod *ast.Module) string {
+	return "ddp_" + strings.TrimSuffix(
 		strings.ReplaceAll(
 			strings.ReplaceAll(
 				filepath.ToSlash(mod.FileName),
@@ -125,7 +127,42 @@ func (c *compiler) getModuleInitDisposeName(mod *ast.Module) (string, string) {
 		),
 		".ddp",
 	)
+}
+
+// creates the name of the module_init function
+func getModuleInitDisposeName(mod *ast.Module) (string, string) {
+	name := getHashableModuleName(mod)
 	return name + "_init", name + "_dispose"
+}
+
+var (
+	hasher            = sha256.New()
+	mangledNamesCache = sync.Map{}
+)
+
+// NOTE: think about making this demanglable
+func (c *compiler) mangledName(decl ast.Declaration) string {
+	// if mangledName, ok := mangledNamesCache.Load(decl); ok {
+	// 	return mangledName.(string)
+	// }
+
+	hasher.Reset()
+	switch decl := decl.(type) {
+	case *ast.FuncDecl:
+		// extern functions may not be name-mangled
+		if ast.IsExternFunc(decl) || decl.IsExternVisible {
+			return decl.Name()
+		}
+	case *ast.VarDecl:
+		// do nothing
+	default:
+		return decl.Name()
+	}
+
+	hasher.Write([]byte(getHashableModuleName(decl.Module())))
+	mangledName := decl.Name() + "_mod_" + hex.EncodeToString(hasher.Sum(nil))
+	// mangledNamesCache.Store(decl, mangledName)
+	return mangledName
 }
 
 // compares two values of same type for equality

--- a/src/ddperror/codes.go
+++ b/src/ddperror/codes.go
@@ -42,6 +42,7 @@ const (
 	SEM_BAD_PUBLIC_MODIFIER                               // a public modifier was missing or similar, for example in a struct decl
 	SEM_BREAK_CONTINUE_NOT_IN_LOOP                        // a break or continue statement was found outside a loop
 	SEM_UNKNOWN_TYPE                                      // a type was used that was not imported yet
+	SEM_UNNECESSARY_EXTERN_VISIBLE                        // a function was specified as both extern visible and extern defined
 )
 
 // type error codes

--- a/src/parser/declarations.go
+++ b/src/parser/declarations.go
@@ -62,6 +62,17 @@ func (p *parser) varDeclaration(startDepth int, isField bool) ast.Declaration {
 	}
 
 	isPublic := p.peekN(startDepth+1).Type == token.OEFFENTLICHE || p.peekN(startDepth+1).Type == token.OEFFENTLICHEN
+
+	isExternVisible := false
+	if isPublic && p.previous().Type == token.COMMA || p.previous().Type == token.EXTERN {
+		if p.previous().Type == token.COMMA {
+			p.consume(token.EXTERN)
+		}
+		p.consume(token.SICHTBARE)
+		isExternVisible = true
+		p.advance()
+	}
+
 	p.decrease()
 	type_start := p.previous()
 	typ := p.parseType()
@@ -142,13 +153,14 @@ func (p *parser) varDeclaration(startDepth int, isField bool) ast.Declaration {
 	}
 
 	return &ast.VarDecl{
-		Range:      token.NewRange(begin, p.previous()),
-		CommentTok: comment,
-		Type:       typ,
-		NameTok:    *name,
-		IsPublic:   isPublic,
-		Mod:        p.module,
-		InitVal:    expr,
+		Range:           token.NewRange(begin, p.previous()),
+		CommentTok:      comment,
+		Type:            typ,
+		NameTok:         *name,
+		IsPublic:        isPublic,
+		IsExternVisible: isExternVisible,
+		Mod:             p.module,
+		InitVal:         expr,
 	}
 }
 
@@ -422,18 +434,18 @@ func (p *parser) funcDeclaration(startDepth int) ast.Declaration {
 	}
 
 	decl := &ast.FuncDecl{
-		Range:      token.NewRange(begin, p.previous()),
-		CommentTok: comment,
-		Tok:        *begin,
-		NameTok:    *funcName,
-		IsPublic:   isPublic,
+		Range:           token.NewRange(begin, p.previous()),
+		CommentTok:      comment,
+		Tok:             *begin,
+		NameTok:         *funcName,
+		IsPublic:        isPublic,
 		IsExternVisible: isExternVisible,
-		Mod:        p.module,
-		Parameters: params,
-		Type:       Typ,
-		Body:       nil,
-		ExternFile: *definedIn,
-		Aliases:    funcAliases,
+		Mod:             p.module,
+		Parameters:      params,
+		Type:            Typ,
+		Body:            nil,
+		ExternFile:      *definedIn,
+		Aliases:         funcAliases,
 	}
 
 	for i := range funcAliases {

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -150,23 +150,14 @@ func (p *parser) declaration() ast.Statement {
 			n = -2
 		}
 
-		switch t := p.peek().Type; t {
+		p.advance()
+		switch t := p.previous().Type; t {
 		case token.ALIAS:
-			p.advance()
 			return p.aliasDecl()
 		case token.FUNKTION:
-			p.advance()
 			return &ast.DeclStmt{Decl: p.funcDeclaration(n - 1)}
 		default:
-			if p.isTypeName(p.peek()) {
-				p.advance()
-				return &ast.DeclStmt{Decl: p.varDeclaration(n-1, false)}
-			}
-		}
-
-		p.decrease() // decrease, so expressionStatement() can recognize it as expression
-		if n == -2 {
-			p.decrease()
+			return &ast.DeclStmt{Decl: p.varDeclaration(n-1, false)}
 		}
 	}
 

--- a/src/parser/type_parsing.go
+++ b/src/parser/type_parsing.go
@@ -11,19 +11,6 @@ import (
 	"github.com/DDP-Projekt/Kompilierer/src/token"
 )
 
-// wether the next token indicates a typename
-func (p *parser) isTypeName(t *token.Token) bool {
-	switch t.Type {
-	case token.ZAHL, token.KOMMAZAHL, token.WAHRHEITSWERT, token.BUCHSTABE, token.TEXT,
-		token.ZAHLEN, token.KOMMAZAHLEN, token.BUCHSTABEN:
-		return true
-	case token.IDENTIFIER:
-		_, exists := p.typeNames[t.Literal]
-		return exists
-	}
-	return false
-}
-
 // converts a TokenType to a Type
 func (p *parser) tokenTypeToType(t token.TokenType) ddptypes.Type {
 	switch t {

--- a/src/token/token_types.go
+++ b/src/token/token_types.go
@@ -141,6 +141,7 @@ const (
 	ELEMENT
 	EXTERN
 	SICHTBAR
+	SICHTBARE
 
 	DOT    // .
 	COMMA  // ,
@@ -290,6 +291,7 @@ var tokenStrings = [...]string{
 	ANSONSTEN:     "ansonsten",
 	EXTERN:        "extern",
 	SICHTBAR:      "sichtbar",
+	SICHTBARE:     "sichtbare",
 
 	DOT:    ".",
 	COMMA:  ",",
@@ -439,6 +441,7 @@ var KeywordMap = map[string]TokenType{
 	"ansonsten":      ANSONSTEN,
 	"extern":         EXTERN,
 	"sichtbar":       SICHTBAR,
+	"sichtbare":      SICHTBARE,
 }
 
 func KeywordToTokenType(keyword string) TokenType {

--- a/src/token/token_types.go
+++ b/src/token/token_types.go
@@ -139,6 +139,8 @@ const (
 	AB
 	ZUM
 	ELEMENT
+	EXTERN
+	SICHTBAR
 
 	DOT    // .
 	COMMA  // ,
@@ -286,6 +288,8 @@ var tokenStrings = [...]string{
 	ELEMENT:       "Element",
 	FALLS:         "falls",
 	ANSONSTEN:     "ansonsten",
+	EXTERN:        "extern",
+	SICHTBAR:      "sichtbar",
 
 	DOT:    ".",
 	COMMA:  ",",
@@ -433,6 +437,8 @@ var KeywordMap = map[string]TokenType{
 	"Element":        ELEMENT,
 	"falls":          FALLS,
 	"ansonsten":      ANSONSTEN,
+	"extern":         EXTERN,
+	"sichtbar":       SICHTBAR,
 }
 
 func KeywordToTokenType(keyword string) TokenType {

--- a/tests/testdata/kddp/multiple_definitions/def1.ddp
+++ b/tests/testdata/kddp/multiple_definitions/def1.ddp
@@ -1,0 +1,8 @@
+Binde "Duden/Ausgabe" ein.
+
+Die öffentliche Funktion foo gibt nichts zurück, macht:
+	Schreibe "foo1" auf eine Zeile.
+Und kann so benutzt werden:
+	"foo"
+
+Die öffentliche Zahl z ist 1.

--- a/tests/testdata/kddp/multiple_definitions/def2.ddp
+++ b/tests/testdata/kddp/multiple_definitions/def2.ddp
@@ -1,0 +1,9 @@
+Binde "Duden/Ausgabe" ein.
+
+Die öffentliche Funktion foo gibt nichts zurück, macht:
+	Schreibe "foo2" auf eine Zeile.
+Und kann so benutzt werden:
+	"foo"
+Die öffentliche Zahl test ist 0.
+
+Die öffentliche Zahl z ist 2.

--- a/tests/testdata/kddp/multiple_definitions/expected.txt
+++ b/tests/testdata/kddp/multiple_definitions/expected.txt
@@ -1,0 +1,3 @@
+foo1
+1
+Not_Mangled

--- a/tests/testdata/kddp/multiple_definitions/expected.txt
+++ b/tests/testdata/kddp/multiple_definitions/expected.txt
@@ -1,3 +1,4 @@
 foo1
 1
 Not_Mangled
+78

--- a/tests/testdata/kddp/multiple_definitions/multiple_definitions.ddp
+++ b/tests/testdata/kddp/multiple_definitions/multiple_definitions.ddp
@@ -10,9 +10,12 @@ Die Funktion Not_Mangled gibt nichts zurück, ist extern sichtbar, macht:
 Und kann so benutzt werden:
 	"Not_Mangled"
 
-Die Funktion Callback gibt nichts zurück,
+Die Funktion Callback gibt eine Zahl zurück,
 ist in "test.c" definiert
 und kann so benutzt werden:
 	"Callback"
 
-Callback.
+Die extern sichtbare Zahl Not_Mangled_Var ist 77.
+Die öffentliche, extern sichtbare Zahl Not_Mangled_Var2 ist 1.
+
+Schreibe Callback auf eine Zeile.

--- a/tests/testdata/kddp/multiple_definitions/multiple_definitions.ddp
+++ b/tests/testdata/kddp/multiple_definitions/multiple_definitions.ddp
@@ -1,0 +1,18 @@
+Binde "def1" ein.
+Binde test aus "def2" ein.
+Binde "Duden/Ausgabe" ein.
+
+foo.
+Schreibe z auf eine Zeile.
+
+Die Funktion Not_Mangled gibt nichts zurück, ist extern sichtbar, macht:
+	Schreibe "Not_Mangled" auf eine Zeile.
+Und kann so benutzt werden:
+	"Not_Mangled"
+
+Die Funktion Callback gibt nichts zurück,
+ist in "test.c" definiert
+und kann so benutzt werden:
+	"Callback"
+
+Callback.

--- a/tests/testdata/kddp/multiple_definitions/test.c
+++ b/tests/testdata/kddp/multiple_definitions/test.c
@@ -1,0 +1,5 @@
+extern void Not_Mangled(void);
+
+void Callback(void) {
+	Not_Mangled();
+}

--- a/tests/testdata/kddp/multiple_definitions/test.c
+++ b/tests/testdata/kddp/multiple_definitions/test.c
@@ -1,5 +1,8 @@
 extern void Not_Mangled(void);
+extern long long Not_Mangled_Var;
+extern long long Not_Mangled_Var2;
 
-void Callback(void) {
+long long Callback(void) {
 	Not_Mangled();
+	return Not_Mangled_Var + Not_Mangled_Var2;
 }


### PR DESCRIPTION
Bug ist im Issue beschrieben.

Ich name-mangling basierend auf dem Module-Pfad implementiert, und neue Syntax hinzugefügt um dieses wenn nötig für einzelne Funktionen/Variablen auszuschalten.

Siehe den neuen Test für Beispiele.