### PR TITLE
entweder ..., oder operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung
 
+- [Added] `entweder ..., oder` Operator
 - [Added] Syntax um Variablen und Funktionen als "extern sichtbar" zu markieren, und somit name-mangling für diese auszuschalten
 - [Fix] Linker Fehler bei mehreren öffentlichen Symbolen mit demselben Namen
 - [Added] Falls Operator. Funktioniert so wie der Ternary Conditional Operator (?:) in anderen Sprachen. 

--- a/src/ast/operators.go
+++ b/src/ast/operators.go
@@ -46,6 +46,7 @@ const (
 	BIN_INVALID      BinaryOperator = iota
 	BIN_AND                         // und
 	BIN_OR                          // oder
+	BIN_XOR                         // entweder ... oder ..
 	BIN_CONCAT                      // verkettet
 	BIN_PLUS                        // plus
 	BIN_MINUS                       // minus
@@ -77,6 +78,8 @@ func (op BinaryOperator) String() string {
 		return "und"
 	case BIN_OR:
 		return "oder"
+	case BIN_XOR:
+		return "entweder oder"
 	case BIN_CONCAT:
 		return "verkettet"
 	case BIN_PLUS:

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -842,6 +842,12 @@ func (c *compiler) VisitBinaryExpr(e *ast.BinaryExpr) ast.VisitResult {
 		c.latestReturn = c.cbb.NewPhi(ir.NewIncoming(lhs, startBlock), ir.NewIncoming(rhs, falseBlock))
 		c.latestReturnType = c.ddpbooltyp
 		return ast.VisitRecurse
+	case ast.BIN_XOR:
+		lhs, _, _ := c.evaluate(e.Lhs)
+		rhs, _, _ := c.evaluate(e.Rhs)
+		c.latestReturn = c.cbb.NewXor(lhs, rhs)
+		c.latestReturnType = c.ddpbooltyp
+		return ast.VisitRecurse
 	case ast.BIN_FIELD_ACCESS:
 		rhs, rhsTyp, _ := c.evaluate(e.Rhs)
 		if structType, isStruct := rhsTyp.(*ddpIrStructType); isStruct {

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -842,12 +842,6 @@ func (c *compiler) VisitBinaryExpr(e *ast.BinaryExpr) ast.VisitResult {
 		c.latestReturn = c.cbb.NewPhi(ir.NewIncoming(lhs, startBlock), ir.NewIncoming(rhs, falseBlock))
 		c.latestReturnType = c.ddpbooltyp
 		return ast.VisitRecurse
-	case ast.BIN_XOR:
-		lhs, _, _ := c.evaluate(e.Lhs)
-		rhs, _, _ := c.evaluate(e.Rhs)
-		c.latestReturn = c.cbb.NewXor(lhs, rhs)
-		c.latestReturnType = c.ddpbooltyp
-		return ast.VisitRecurse
 	case ast.BIN_FIELD_ACCESS:
 		rhs, rhsTyp, _ := c.evaluate(e.Rhs)
 		if structType, isStruct := rhsTyp.(*ddpIrStructType); isStruct {
@@ -874,6 +868,9 @@ func (c *compiler) VisitBinaryExpr(e *ast.BinaryExpr) ast.VisitResult {
 	rhs, rhsTyp, isTempRhs := c.evaluate(e.Rhs)
 	// big switches on the different type combinations
 	switch e.Operator {
+	case ast.BIN_XOR:
+		c.latestReturn = c.cbb.NewXor(lhs, rhs)
+		c.latestReturnType = c.ddpbooltyp
 	case ast.BIN_CONCAT:
 		var (
 			result    value.Value

--- a/src/parser/expressions.go
+++ b/src/parser/expressions.go
@@ -37,7 +37,7 @@ func (p *parser) expression() ast.Expression {
 
 // <a> wenn <b>, sonst <c>
 func (p *parser) ifExpression() ast.Expression {
-	expr := p.boolOR()
+	expr := p.boolXOR()
 	for p.matchN(token.COMMA, token.FALLS) {
 		tok := p.previous()
 		cond := p.ifExpression()
@@ -56,6 +56,27 @@ func (p *parser) ifExpression() ast.Expression {
 		}
 	}
 	return expr
+}
+
+// entweder <a> oder <b> ist
+func (p *parser) boolXOR() ast.Expression {
+	for p.match(token.ENTWEDER) {
+		tok := p.previous()
+		lhs := p.boolOR()
+		p.consume(token.COMMA, token.ODER)
+		rhs := p.boolOR()
+		return &ast.BinaryExpr{
+			Range: token.Range{
+				Start: tok.Range.Start,
+				End:   rhs.GetRange().End,
+			},
+			Tok:      *tok,
+			Lhs:      lhs,
+			Operator: ast.BIN_UNEQUAL,
+			Rhs:      rhs,
+		}
+	}
+	return p.boolOR()
 }
 
 func (p *parser) boolOR() ast.Expression {

--- a/src/parser/expressions.go
+++ b/src/parser/expressions.go
@@ -72,7 +72,7 @@ func (p *parser) boolXOR() ast.Expression {
 			},
 			Tok:      *tok,
 			Lhs:      lhs,
-			Operator: ast.BIN_UNEQUAL,
+			Operator: ast.BIN_XOR,
 			Rhs:      rhs,
 		}
 	}

--- a/src/parser/typechecker/typechecker.go
+++ b/src/parser/typechecker/typechecker.go
@@ -365,7 +365,7 @@ func (t *Typechecker) VisitBinaryExpr(expr *ast.BinaryExpr) ast.VisitResult {
 	case ast.BIN_MOD:
 		validate(ddptypes.ZAHL)
 		t.latestReturnedType = ddptypes.ZAHL
-	case ast.BIN_AND, ast.BIN_OR:
+	case ast.BIN_AND, ast.BIN_OR, ast.BIN_XOR:
 		validate(ddptypes.WAHRHEITSWERT)
 		t.latestReturnedType = ddptypes.WAHRHEITSWERT
 	case ast.BIN_LEFT_SHIFT, ast.BIN_RIGHT_SHIFT:

--- a/src/token/token_types.go
+++ b/src/token/token_types.go
@@ -25,6 +25,7 @@ const (
 	BETRAG       // Betrag (von)
 	UND          // und
 	ODER         // oder
+	ENTWEDER     // entweder
 	NICHT        // nicht
 	GLEICH       // gleich
 	UNGLEICH     // ungleich
@@ -175,6 +176,7 @@ var tokenStrings = [...]string{
 	BETRAG:       "Betrag",
 	UND:          "und",
 	ODER:         "oder",
+	ENTWEDER:     "entweder",
 	NICHT:        "nicht",
 	GLEICH:       "gleich",
 	UNGLEICH:     "ungleich",
@@ -319,6 +321,7 @@ var KeywordMap = map[string]TokenType{
 	"Betrag":         BETRAG,
 	"und":            UND,
 	"oder":           ODER,
+	"entweder":       ENTWEDER,
 	"nicht":          NICHT,
 	"gleich":         GLEICH,
 	"ungleich":       UNGLEICH,

--- a/tests/testdata/kddp/bool_math/bool_math.ddp
+++ b/tests/testdata/kddp/bool_math/bool_math.ddp
@@ -18,6 +18,22 @@ Schreibe den Buchstaben ','.
 Schreibe den Wahrheitswert (falsch oder falsch).
 Schreibe den Buchstaben '\n'.
 
+Schreibe den Wahrheitswert (entweder wahr, oder wahr).
+Schreibe den Buchstaben ','.
+Schreibe den Wahrheitswert (entweder wahr, oder falsch).
+Schreibe den Buchstaben ','.
+Schreibe den Wahrheitswert (entweder falsch, oder wahr).
+Schreibe den Buchstaben ','.
+Schreibe den Wahrheitswert (entweder falsch, oder falsch).
+Schreibe den Buchstaben '\n'.
+
+Schreibe den Wahrheitswert (entweder wahr oder falsch, oder wahr).
+Schreibe den Buchstaben ','.
+Schreibe den Wahrheitswert (entweder wahr, oder falsch oder wahr).
+Schreibe den Buchstaben ','.
+Schreibe den Wahrheitswert (entweder wahr oder falsch, oder falsch oder wahr).
+Schreibe den Buchstaben '\n'.
+
 Schreibe den Wahrheitswert (nicht wahr).
 Schreibe den Buchstaben ','.
 Schreibe den Wahrheitswert (nicht falsch).

--- a/tests/testdata/kddp/bool_math/expected.txt
+++ b/tests/testdata/kddp/bool_math/expected.txt
@@ -1,3 +1,5 @@
 wahr,falsch,falsch,falsch
 wahr,wahr,wahr,falsch
+falsch,wahr,wahr,falsch
+falsch,falsch,falsch
 falsch,wahr


### PR DESCRIPTION
## Warum?
Um eine `entweder ... oder ...` Entscheidung in DDP machen zu können, müsste man, entweder den Boolschen Ausdruck ausschreiben, oder den ungleich Operator benutzen.

Das Ausschreiben ist da aber viel zu lang: `Wenn (nicht a und b) ist oder (a und nicht b) ist, ...` und den ungleich Operator bei Wahrheitswerten zu benutzen macht Sprachlich wenig sinn.

## Beispiel
```
Die Zahl z ist 4.
Der Text t ist "".

Wenn entweder t leer ist, oder z größer als 5 ist, Schreibe "hi". [ Ausgabe: hi ]
```

## Implementation
Der `entweder ..., oder ...` ist nur Zucker für den `ungleich` operator, da er sich genau so verhält wie ein XOR.

---

Hinweis: Diese PR hat nichts mit #65 zu tun - es fügt nur `entweder ... oder` als Binären Operator hinzu.
