### PR TITLE
Optionales "ist" in equality und comparison Ausdrücken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung
 
+- [Changed] "ist" nach Vergleichen ist jetzt Optional, falls davor bereits ein "ist" steht
 - [Added] Syntax um Variablen und Funktionen als "extern sichtbar" zu markieren, und somit name-mangling für diese auszuschalten
 - [Fix] Linker Fehler bei mehreren öffentlichen Symbolen mit demselben Namen
 - [Added] Falls Operator. Funktioniert so wie der Ternary Conditional Operator (?:) in anderen Sprachen. 

--- a/src/parser/expressions.go
+++ b/src/parser/expressions.go
@@ -172,7 +172,11 @@ func (p *parser) equality() ast.Expression {
 			Operator: operator,
 			Rhs:      rhs,
 		}
-		p.consume(token.IST)
+		if p.previous().Type != token.IST {
+			p.consume(token.IST)
+		} else {
+			p.match(token.IST)
+		}
 	}
 	return expr
 }
@@ -224,7 +228,11 @@ func (p *parser) comparison() ast.Expression {
 				Rhs:      rhs,
 			}
 		}
-		p.consume(token.IST)
+		if p.previous().Type != token.IST {
+			p.consume(token.IST)
+		} else {
+			p.match(token.IST)
+		}
 	}
 	return expr
 }


### PR DESCRIPTION
Vorher:
```ddp
Wenn wahr ungleich 2 größer als 3 ist ist, Schreibe "ho".
Wenn wahr ungleich 2 größer als 3 ist, Schreibe "ho". [ Syntax Fehler ]
```
Jetzt:
```ddp
Wenn wahr ungleich 2 größer als 3 ist ist, Schreibe "ho". [ Immer noch valide für den Fall, dass mit Aliasen edge-cases auftreten ]
Wenn wahr ungleich 2 größer als 3 ist, Schreibe "ho". [ Kein Syntax Fehler ]
```