### PR TITLE
Forward declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung
 
+- [Added] Vorwärts Deklarationen
 - [Added] _Ref Versionen für einige Duden/Listen und Duden/Texte Funktionen
 - [Changed] Iterierenden Schleifen über Texte haben nun eine Zeitkomplexität von O(n) (anstatt O(n^2))
 - [Fix] utf8 Texte

--- a/lib/stdlib/Makefile
+++ b/lib/stdlib/Makefile
@@ -38,7 +38,6 @@ endif
 ifneq ($(OS),Windows_NT)
 $(PCRE2_OUT_FILE_NAME):
 	@echo "pcre2 is already provided on linux systems"
-	echo "dummy file" > $(PCRE2_OUT_FILE_NAME)
 else
 $(PCRE2_OUT_FILE_NAME): | checkout-pcre2
 	@echo "building pcre2"

--- a/lib/stdlib/Makefile
+++ b/lib/stdlib/Makefile
@@ -38,6 +38,7 @@ endif
 ifneq ($(OS),Windows_NT)
 $(PCRE2_OUT_FILE_NAME):
 	@echo "pcre2 is already provided on linux systems"
+	echo "dummy file" > $(PCRE2_OUT_FILE_NAME)
 else
 $(PCRE2_OUT_FILE_NAME): | checkout-pcre2
 	@echo "building pcre2"

--- a/src/ast/annotators/const_func_param.go
+++ b/src/ast/annotators/const_func_param.go
@@ -68,8 +68,12 @@ func (a *ConstFuncParamAnnotator) VisitFuncDecl(decl *ast.FuncDecl) ast.VisitRes
 	}
 	// track all the function parameters
 	// and initially assume they are const
+	body := decl.Body
+	if ast.IsForwardDecl(decl) {
+		body = decl.Def.Body
+	}
 	for _, funcParam := range decl.Parameters {
-		param, exists, isVar := decl.Body.Symbols.LookupDecl(funcParam.Name.Literal)
+		param, exists, isVar := body.Symbols.LookupDecl(funcParam.Name.Literal)
 		if exists && isVar {
 			a.currentParams[param.(*ast.VarDecl)] = true
 			attachement.IsConst[funcParam.Name.Literal] = true

--- a/src/ast/helper.go
+++ b/src/ast/helper.go
@@ -9,7 +9,12 @@ import (
 
 // check if the function is defined externally
 func IsExternFunc(fun *FuncDecl) bool {
-	return fun.Body == nil
+	return fun.Body == nil && fun.Def == nil
+}
+
+// check if the declaration is only a forward decl
+func IsForwardDecl(fun *FuncDecl) bool {
+	return fun.Def != nil
 }
 
 func IsOperatorOverload(fun *FuncDecl) bool {

--- a/src/ast/helper_visitor.go
+++ b/src/ast/helper_visitor.go
@@ -188,6 +188,14 @@ func (h *helperVisitor) VisitFuncDecl(decl *FuncDecl) VisitResult {
 	return h.visitChildren(result, decl.Body)
 }
 
+func (h *helperVisitor) VisitFuncDef(decl *FuncDef) VisitResult {
+	result := VisitRecurse
+	if vis, ok := h.actualVisitor.(FuncDefVisitor); ok {
+		result = vis.VisitFuncDef(decl)
+	}
+	return h.visitChildren(result, decl.Body)
+}
+
 func (h *helperVisitor) VisitStructDecl(decl *StructDecl) VisitResult {
 	result := VisitRecurse
 	if vis, ok := h.actualVisitor.(StructDeclVisitor); ok {
@@ -467,7 +475,7 @@ func (h *helperVisitor) VisitForRangeStmt(stmt *ForRangeStmt) VisitResult {
 }
 
 func (h *helperVisitor) VisitBreakContinueStmt(stmt *BreakContinueStmt) VisitResult {
-	if vis, ok := h.actualVisitor.(BreakContineStmtVisitor); ok {
+	if vis, ok := h.actualVisitor.(BreakContinueStmtVisitor); ok {
 		return vis.VisitBreakContinueStmt(stmt)
 	}
 	return VisitRecurse

--- a/src/ast/printer.go
+++ b/src/ast/printer.go
@@ -88,17 +88,26 @@ func (pr *printer) VisitFuncDecl(decl *FuncDecl) VisitResult {
 	if IsExternFunc(decl) {
 		msg += " [Extern]"
 	}
+	if IsForwardDecl(decl) {
+		msg += " [Forward Decl]"
+	}
 	if decl.IsExternVisible {
 		msg += " [Extern Visible]"
 	}
 	if decl.CommentTok != nil {
 		msg += fmt.Sprintf(commentFmt, strings.Trim(decl.CommentTok.Literal, commentCutset), pr.currentIdent, " ")
 	}
-	if IsExternFunc(decl) {
+	if IsExternFunc(decl) || IsForwardDecl(decl) {
 		pr.parenthesizeNode(msg)
 	} else {
 		pr.parenthesizeNode(msg, decl.Body)
 	}
+	return VisitRecurse
+}
+
+func (pr *printer) VisitFuncDef(decl *FuncDef) VisitResult {
+	msg := fmt.Sprintf("FuncDef[%s]", decl.Func.Name())
+	pr.parenthesizeNode(msg, decl.Body)
 	return VisitRecurse
 }
 

--- a/src/ast/visitor.go
+++ b/src/ast/visitor.go
@@ -27,6 +27,7 @@ type FullVisitor interface {
 	BadDeclVisitor
 	VarDeclVisitor
 	FuncDeclVisitor
+	FuncDefVisitor
 	StructDeclVisitor
 	TypeAliasDeclVisitor
 	TypeDefDeclVisitor
@@ -69,7 +70,7 @@ type FullVisitor interface {
 	WhileStmtVisitor
 	ForStmtVisitor
 	ForRangeStmtVisitor
-	BreakContineStmtVisitor
+	BreakContinueStmtVisitor
 	ReturnStmtVisitor
 	TodoStmtVisitor
 }
@@ -86,6 +87,10 @@ type (
 	FuncDeclVisitor interface {
 		Visitor
 		VisitFuncDecl(*FuncDecl) VisitResult
+	}
+	FuncDefVisitor interface {
+		Visitor
+		VisitFuncDef(*FuncDef) VisitResult
 	}
 	StructDeclVisitor interface {
 		Visitor
@@ -217,7 +222,7 @@ type (
 		Visitor
 		VisitForRangeStmt(*ForRangeStmt) VisitResult
 	}
-	BreakContineStmtVisitor interface {
+	BreakContinueStmtVisitor interface {
 		Visitor
 		VisitBreakContinueStmt(*BreakContinueStmt) VisitResult
 	}
@@ -230,3 +235,358 @@ type (
 		VisitTodoStmt(*TodoStmt) VisitResult
 	}
 )
+
+// helper types to easily create small visitors
+
+type BadDeclVisitorFunc func(*BadDecl) VisitResult
+
+var _ BadDeclVisitor = (BadDeclVisitorFunc)(nil)
+
+func (BadDeclVisitorFunc) Visitor() {}
+func (f BadDeclVisitorFunc) VisitBadDecl(stmt *BadDecl) VisitResult {
+	return f(stmt)
+}
+
+type VarDeclVisitorFunc func(*VarDecl) VisitResult
+
+var _ VarDeclVisitor = (VarDeclVisitorFunc)(nil)
+
+func (VarDeclVisitorFunc) Visitor() {}
+func (f VarDeclVisitorFunc) VisitVarDecl(stmt *VarDecl) VisitResult {
+	return f(stmt)
+}
+
+type FuncDeclVisitorFunc func(*FuncDecl) VisitResult
+
+var _ FuncDeclVisitor = (FuncDeclVisitorFunc)(nil)
+
+func (FuncDeclVisitorFunc) Visitor() {}
+func (f FuncDeclVisitorFunc) VisitFuncDecl(stmt *FuncDecl) VisitResult {
+	return f(stmt)
+}
+
+type FuncDefVisitorFunc func(*FuncDef) VisitResult
+
+var _ FuncDefVisitor = (FuncDefVisitorFunc)(nil)
+
+func (FuncDefVisitorFunc) Visitor() {}
+func (f FuncDefVisitorFunc) VisitFuncDef(stmt *FuncDef) VisitResult {
+	return f(stmt)
+}
+
+type StructDeclVisitorFunc func(*StructDecl) VisitResult
+
+var _ StructDeclVisitor = (StructDeclVisitorFunc)(nil)
+
+func (StructDeclVisitorFunc) Visitor() {}
+func (f StructDeclVisitorFunc) VisitStructDecl(stmt *StructDecl) VisitResult {
+	return f(stmt)
+}
+
+type TypeAliasDeclVisitorFunc func(*TypeAliasDecl) VisitResult
+
+var _ TypeAliasDeclVisitor = (TypeAliasDeclVisitorFunc)(nil)
+
+func (TypeAliasDeclVisitorFunc) Visitor() {}
+func (f TypeAliasDeclVisitorFunc) VisitTypeAliasDecl(stmt *TypeAliasDecl) VisitResult {
+	return f(stmt)
+}
+
+type TypeDefDeclVisitorFunc func(*TypeDefDecl) VisitResult
+
+var _ TypeDefDeclVisitor = (TypeDefDeclVisitorFunc)(nil)
+
+func (TypeDefDeclVisitorFunc) Visitor() {}
+func (f TypeDefDeclVisitorFunc) VisitTypeDefDecl(stmt *TypeDefDecl) VisitResult {
+	return f(stmt)
+}
+
+// Expressions
+type BadExprVisitorFunc func(*BadExpr) VisitResult
+
+var _ BadExprVisitor = (BadExprVisitorFunc)(nil)
+
+func (BadExprVisitorFunc) Visitor() {}
+func (f BadExprVisitorFunc) VisitBadExpr(expr *BadExpr) VisitResult {
+	return f(expr)
+}
+
+type IdentVisitorFunc func(*Ident) VisitResult
+
+var _ IdentVisitor = (IdentVisitorFunc)(nil)
+
+func (IdentVisitorFunc) Visitor() {}
+func (f IdentVisitorFunc) VisitIdent(expr *Ident) VisitResult {
+	return f(expr)
+}
+
+type IndexingVisitorFunc func(*Indexing) VisitResult
+
+var _ IndexingVisitor = (IndexingVisitorFunc)(nil)
+
+func (IndexingVisitorFunc) Visitor() {}
+func (f IndexingVisitorFunc) VisitIndexing(expr *Indexing) VisitResult {
+	return f(expr)
+}
+
+type FieldAccessVisitorFunc func(*FieldAccess) VisitResult
+
+var _ FieldAccessVisitor = (FieldAccessVisitorFunc)(nil)
+
+func (FieldAccessVisitorFunc) Visitor() {}
+func (f FieldAccessVisitorFunc) VisitFieldAccess(expr *FieldAccess) VisitResult {
+	return f(expr)
+}
+
+type IntLitVisitorFunc func(*IntLit) VisitResult
+
+var _ IntLitVisitor = (IntLitVisitorFunc)(nil)
+
+func (IntLitVisitorFunc) Visitor() {}
+func (f IntLitVisitorFunc) VisitIntLit(expr *IntLit) VisitResult {
+	return f(expr)
+}
+
+type FloatLitVisitorFunc func(*FloatLit) VisitResult
+
+var _ FloatLitVisitor = (FloatLitVisitorFunc)(nil)
+
+func (FloatLitVisitorFunc) Visitor() {}
+func (f FloatLitVisitorFunc) VisitFloatLit(expr *FloatLit) VisitResult {
+	return f(expr)
+}
+
+type BoolLitVisitorFunc func(*BoolLit) VisitResult
+
+var _ BoolLitVisitor = (BoolLitVisitorFunc)(nil)
+
+func (BoolLitVisitorFunc) Visitor() {}
+func (f BoolLitVisitorFunc) VisitBoolLit(expr *BoolLit) VisitResult {
+	return f(expr)
+}
+
+type CharLitVisitorFunc func(*CharLit) VisitResult
+
+var _ CharLitVisitor = (CharLitVisitorFunc)(nil)
+
+func (CharLitVisitorFunc) Visitor() {}
+func (f CharLitVisitorFunc) VisitCharLit(expr *CharLit) VisitResult {
+	return f(expr)
+}
+
+type StringLitVisitorFunc func(*StringLit) VisitResult
+
+var _ StringLitVisitor = (StringLitVisitorFunc)(nil)
+
+func (StringLitVisitorFunc) Visitor() {}
+func (f StringLitVisitorFunc) VisitStringLit(expr *StringLit) VisitResult {
+	return f(expr)
+}
+
+type ListLitVisitorFunc func(*ListLit) VisitResult
+
+var _ ListLitVisitor = (ListLitVisitorFunc)(nil)
+
+func (ListLitVisitorFunc) Visitor() {}
+func (f ListLitVisitorFunc) VisitListLit(expr *ListLit) VisitResult {
+	return f(expr)
+}
+
+type UnaryExprVisitorFunc func(*UnaryExpr) VisitResult
+
+var _ UnaryExprVisitor = (UnaryExprVisitorFunc)(nil)
+
+func (UnaryExprVisitorFunc) Visitor() {}
+func (f UnaryExprVisitorFunc) VisitUnaryExpr(expr *UnaryExpr) VisitResult {
+	return f(expr)
+}
+
+type BinaryExprVisitorFunc func(*BinaryExpr) VisitResult
+
+var _ BinaryExprVisitor = (BinaryExprVisitorFunc)(nil)
+
+func (BinaryExprVisitorFunc) Visitor() {}
+func (f BinaryExprVisitorFunc) VisitBinaryExpr(expr *BinaryExpr) VisitResult {
+	return f(expr)
+}
+
+type TernaryExprVisitorFunc func(*TernaryExpr) VisitResult
+
+var _ TernaryExprVisitor = (TernaryExprVisitorFunc)(nil)
+
+func (TernaryExprVisitorFunc) Visitor() {}
+func (f TernaryExprVisitorFunc) VisitTernaryExpr(expr *TernaryExpr) VisitResult {
+	return f(expr)
+}
+
+type CastExprVisitorFunc func(*CastExpr) VisitResult
+
+var _ CastExprVisitor = (CastExprVisitorFunc)(nil)
+
+func (CastExprVisitorFunc) Visitor() {}
+func (f CastExprVisitorFunc) VisitCastExpr(expr *CastExpr) VisitResult {
+	return f(expr)
+}
+
+type TypeOpExprVisitorFunc func(*TypeOpExpr) VisitResult
+
+var _ TypeOpExprVisitor = (TypeOpExprVisitorFunc)(nil)
+
+func (TypeOpExprVisitorFunc) Visitor() {}
+func (f TypeOpExprVisitorFunc) VisitTypeOpExpr(expr *TypeOpExpr) VisitResult {
+	return f(expr)
+}
+
+type TypeCheckVisitorFunc func(*TypeCheck) VisitResult
+
+var _ TypeCheckVisitor = (TypeCheckVisitorFunc)(nil)
+
+func (TypeCheckVisitorFunc) Visitor() {}
+func (f TypeCheckVisitorFunc) VisitTypeCheck(expr *TypeCheck) VisitResult {
+	return f(expr)
+}
+
+type GroupingVisitorFunc func(*Grouping) VisitResult
+
+var _ GroupingVisitor = (GroupingVisitorFunc)(nil)
+
+func (GroupingVisitorFunc) Visitor() {}
+func (f GroupingVisitorFunc) VisitGrouping(expr *Grouping) VisitResult {
+	return f(expr)
+}
+
+type FuncCallVisitorFunc func(*FuncCall) VisitResult
+
+var _ FuncCallVisitor = (FuncCallVisitorFunc)(nil)
+
+func (FuncCallVisitorFunc) Visitor() {}
+func (f FuncCallVisitorFunc) VisitFuncCall(expr *FuncCall) VisitResult {
+	return f(expr)
+}
+
+type StructLiteralVisitorFunc func(*StructLiteral) VisitResult
+
+var _ StructLiteralVisitor = (StructLiteralVisitorFunc)(nil)
+
+func (StructLiteralVisitorFunc) Visitor() {}
+func (f StructLiteralVisitorFunc) VisitStructLiteral(expr *StructLiteral) VisitResult {
+	return f(expr)
+}
+
+// Statements
+type BadStmtVisitorFunc func(*BadStmt) VisitResult
+
+var _ BadStmtVisitor = (BadStmtVisitorFunc)(nil)
+
+func (BadStmtVisitorFunc) Visitor() {}
+func (f BadStmtVisitorFunc) VisitBadStmt(stmt *BadStmt) VisitResult {
+	return f(stmt)
+}
+
+type DeclStmtVisitorFunc func(*DeclStmt) VisitResult
+
+var _ DeclStmtVisitor = (DeclStmtVisitorFunc)(nil)
+
+func (DeclStmtVisitorFunc) Visitor() {}
+func (f DeclStmtVisitorFunc) VisitDeclStmt(stmt *DeclStmt) VisitResult {
+	return f(stmt)
+}
+
+type ExprStmtVisitorFunc func(*ExprStmt) VisitResult
+
+var _ ExprStmtVisitor = (ExprStmtVisitorFunc)(nil)
+
+func (ExprStmtVisitorFunc) Visitor() {}
+func (f ExprStmtVisitorFunc) VisitExprStmt(stmt *ExprStmt) VisitResult {
+	return f(stmt)
+}
+
+type ImportStmtVisitorFunc func(*ImportStmt) VisitResult
+
+var _ ImportStmtVisitor = (ImportStmtVisitorFunc)(nil)
+
+func (ImportStmtVisitorFunc) Visitor() {}
+func (f ImportStmtVisitorFunc) VisitImportStmt(stmt *ImportStmt) VisitResult {
+	return f(stmt)
+}
+
+type AssignStmtVisitorFunc func(*AssignStmt) VisitResult
+
+var _ AssignStmtVisitor = (AssignStmtVisitorFunc)(nil)
+
+func (AssignStmtVisitorFunc) Visitor() {}
+func (f AssignStmtVisitorFunc) VisitAssignStmt(stmt *AssignStmt) VisitResult {
+	return f(stmt)
+}
+
+type BlockStmtVisitorFunc func(*BlockStmt) VisitResult
+
+var _ BlockStmtVisitor = (BlockStmtVisitorFunc)(nil)
+
+func (BlockStmtVisitorFunc) Visitor() {}
+func (f BlockStmtVisitorFunc) VisitBlockStmt(stmt *BlockStmt) VisitResult {
+	return f(stmt)
+}
+
+type IfStmtVisitorFunc func(*IfStmt) VisitResult
+
+var _ IfStmtVisitor = (IfStmtVisitorFunc)(nil)
+
+func (IfStmtVisitorFunc) Visitor() {}
+func (f IfStmtVisitorFunc) VisitIfStmt(stmt *IfStmt) VisitResult {
+	return f(stmt)
+}
+
+type WhileStmtVisitorFunc func(*WhileStmt) VisitResult
+
+var _ WhileStmtVisitor = (WhileStmtVisitorFunc)(nil)
+
+func (WhileStmtVisitorFunc) Visitor() {}
+func (f WhileStmtVisitorFunc) VisitWhileStmt(stmt *WhileStmt) VisitResult {
+	return f(stmt)
+}
+
+type ForStmtVisitorFunc func(*ForStmt) VisitResult
+
+var _ ForStmtVisitor = (ForStmtVisitorFunc)(nil)
+
+func (ForStmtVisitorFunc) Visitor() {}
+func (f ForStmtVisitorFunc) VisitForStmt(stmt *ForStmt) VisitResult {
+	return f(stmt)
+}
+
+type ForRangeStmtVisitorFunc func(*ForRangeStmt) VisitResult
+
+var _ ForRangeStmtVisitor = (ForRangeStmtVisitorFunc)(nil)
+
+func (ForRangeStmtVisitorFunc) Visitor() {}
+func (f ForRangeStmtVisitorFunc) VisitForRangeStmt(stmt *ForRangeStmt) VisitResult {
+	return f(stmt)
+}
+
+type BreakContinueStmtVisitorFunc func(*BreakContinueStmt) VisitResult
+
+var _ BreakContinueStmtVisitor = (BreakContinueStmtVisitorFunc)(nil)
+
+func (BreakContinueStmtVisitorFunc) Visitor() {}
+func (f BreakContinueStmtVisitorFunc) VisitBreakContinueStmt(stmt *BreakContinueStmt) VisitResult {
+	return f(stmt)
+}
+
+type ReturnStmtVisitorFunc func(*ReturnStmt) VisitResult
+
+var _ ReturnStmtVisitor = (ReturnStmtVisitorFunc)(nil)
+
+func (ReturnStmtVisitorFunc) Visitor() {}
+func (f ReturnStmtVisitorFunc) VisitReturnStmt(stmt *ReturnStmt) VisitResult {
+	return f(stmt)
+}
+
+type TodoStmtVisitorFunc func(*TodoStmt) VisitResult
+
+var _ TodoStmtVisitor = (TodoStmtVisitorFunc)(nil)
+
+func (TodoStmtVisitorFunc) Visitor() {}
+func (f TodoStmtVisitorFunc) VisitTodoStmt(stmt *TodoStmt) VisitResult {
+	return f(stmt)
+}

--- a/src/ddperror/codes.go
+++ b/src/ddperror/codes.go
@@ -48,6 +48,9 @@ const (
 	SEM_OVERLOAD_ALREADY_DEFINED                          // an overload for the given types is already present
 	SEM_TODO_STMT_FOUND                                   // ... wurde gefunden
 	SEM_BAD_TYPEDEF                                       // any was typedefed
+	SEM_FORWARD_DECL_WITHOUT_DEF                          // a function was declared as forward decl but never defined
+	SEM_WRONG_DECL_MODULE                                 // a definition was provided for a function from a different module
+	SEM_DEFINITION_ALREADY_DEFINED                        // a forward decl was already defined
 )
 
 // type error codes

--- a/src/parser/declarations.go
+++ b/src/parser/declarations.go
@@ -661,9 +661,9 @@ func (p *parser) getDeclForDefinition(nameTok *token.Token) *ast.FuncDecl {
 	} else if funcDecl, ok := decl.(*ast.FuncDecl); !ok {
 		p.err(ddperror.SEM_BAD_NAME_CONTEXT, nameTok.Range, fmt.Sprintf("Der Name '%s' steht für eine Variable oder Struktur und nicht für eine Funktion", nameTok.Literal))
 	} else if funcDecl.Mod != p.module {
-		p.err(ddperror.SEM_WRONG_DECL_MODULE, nameTok.Range, fmt.Sprintf("Es können nur Funktionen aus demselben Modul definiert werden"))
+		p.err(ddperror.SEM_WRONG_DECL_MODULE, nameTok.Range, "Es können nur Funktionen aus demselben Modul definiert werden")
 	} else if funcDecl.Body != nil || funcDecl.ExternFile.Type != token.ILLEGAL || funcDecl.Def != nil {
-		p.err(ddperror.SEM_DEFINITION_ALREADY_DEFINED, nameTok.Range, fmt.Sprintf("Die Funktion '%s' wurde bereits definiert"))
+		p.err(ddperror.SEM_DEFINITION_ALREADY_DEFINED, nameTok.Range, fmt.Sprintf("Die Funktion '%s' wurde bereits definiert", nameTok.Literal))
 	} else {
 		return funcDecl
 	}

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -298,7 +298,7 @@ func (p *parser) validateForwardDecls() {
 		if decl.Body == nil && decl.ExternFile.Type == token.ILLEGAL && decl.Def == nil {
 			p.err(ddperror.SEM_FORWARD_DECL_WITHOUT_DEF,
 				decl.NameTok.Range,
-				fmt.Sprintf("Die Funktion '%s' wurde nur deklariert aber nie definiert"))
+				fmt.Sprintf("Die Funktion '%s' wurde nur deklariert aber nie definiert", decl.Name()))
 			p.panicMode = false
 		}
 		return ast.VisitSkipChildren

--- a/src/parser/resolver/resolver.go
+++ b/src/parser/resolver/resolver.go
@@ -117,6 +117,11 @@ func (r *Resolver) VisitFuncDecl(decl *ast.FuncDecl) ast.VisitResult {
 	return ast.VisitRecurse
 }
 
+func (r *Resolver) VisitFuncDef(def *ast.FuncDef) ast.VisitResult {
+	def.Func.Def = def
+	return ast.VisitRecurse
+}
+
 func (r *Resolver) VisitStructDecl(decl *ast.StructDecl) ast.VisitResult {
 	if !ast.IsGlobalScope(r.CurrentTable) {
 		r.err(ddperror.SEM_NON_GLOBAL_TYPE_DECL, decl.NameTok.Range, "Es können nur globale Typen deklariert werden")

--- a/src/parser/typechecker/typechecker.go
+++ b/src/parser/typechecker/typechecker.go
@@ -140,6 +140,10 @@ func (t *Typechecker) VisitFuncDecl(decl *ast.FuncDecl) ast.VisitResult {
 	return ast.VisitRecurse
 }
 
+func (t *Typechecker) VisitFuncDef(def *ast.FuncDef) ast.VisitResult {
+	return ast.VisitRecurse
+}
+
 func (t *Typechecker) VisitStructDecl(decl *ast.StructDecl) ast.VisitResult {
 	for _, field := range decl.Fields {
 		// don't check BadDecls

--- a/src/token/token_types.go
+++ b/src/token/token_types.go
@@ -152,6 +152,8 @@ const (
 	OPERATOR
 	VARIABLE
 	VARIABLEN
+	WIRD
+	SPÄTER
 
 	DOT     // .
 	COMMA   // ,
@@ -313,6 +315,8 @@ var tokenStrings = [...]string{
 	VARIABLEN:     "Variablen",
 	KEIN:          "kein",
 	KEINE:         "keine",
+	WIRD:          "wird",
+	SPÄTER:        "später",
 
 	DOT:     ".",
 	COMMA:   ",",
@@ -478,6 +482,9 @@ var KeywordMap = map[string]TokenType{
 	"Variablen":      VARIABLEN,
 	"kein":           KEIN,
 	"keine":          KEINE,
+	"wird":           WIRD,
+	"später":         SPÄTER,
+	"spaeter":        SPÄTER,
 }
 
 func KeywordToTokenType(keyword string) TokenType {

--- a/tests/testdata/kddp/forward_declarations/expected.txt
+++ b/tests/testdata/kddp/forward_declarations/expected.txt
@@ -1,0 +1,3 @@
+baz fertig
+bar
+foo fertig

--- a/tests/testdata/kddp/forward_declarations/forward_declarations.ddp
+++ b/tests/testdata/kddp/forward_declarations/forward_declarations.ddp
@@ -1,0 +1,32 @@
+Binde "Duden/Ausgabe" ein.
+
+Die Funktion foo mit dem Parameter a vom Typ Zahl, gibt eine Zahl zurück,
+wird später definiert
+und kann so benutzt werden:
+	"foo <a>"
+
+Die Funktion bar gibt nichts zurück,
+wird später definiert
+und kann so benutzt werden:
+	"bar"
+
+Die Funktion baz mit dem Parameter a vom Typ Zahl, gibt eine Zahl zurück, macht:
+	Wenn a gleich 0 ist, dann:
+		Schreibe "baz fertig" auf eine Zeile.
+		Gib 0 zurück.
+	Gib foo (a minus 1) zurück.
+Und kann so benutzt werden:
+	"baz <a>"
+
+foo 3.
+bar.
+baz 3.
+
+Die Funktion foo macht:
+	Wenn a gleich 0 ist, dann:
+		Schreibe "foo fertig" auf eine Zeile.
+		Gib 0 zurück.
+	Gib baz (a minus 1) zurück.
+	
+Die Funktion bar macht:
+	Schreibe "bar" auf eine Zeile.


### PR DESCRIPTION
Irgendwann ist das Ziel, dass Deklarationen in DDP keiner Reihenfolge mehr folgen müssen. Das würde einen Pre-Processor erfordern und wird unglaublich aufwendig zu implementieren, wie ich auf den branches pre-processing und pre-processor feststellen musste.

Da ich vorerst an wichtigeren und interessanteren Features arbeiten möchte ist hier eine PR für forward-declarations.

Für die Syntax siehe den forward_declarations test.

Falls wir in der Zukunft einen Pre-Processor implementieren könnte man dieses Feature wieder entfernen.