### PR TITLE
External libraries now live in a seperate directory

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,9 +68,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: |
-          ${{ github.workspace }}/lib/stdlib/pcre2_build/
-          ${{ github.workspace }}/lib/stdlib/libpcre2-8.a
-        key: ${{ runner.os }}-pcre2-${{ hashFiles('**/lib/stdlib/pcre2_build/**', '**/lib/stdlib/libpcre2-8.a') }}
+          ${{ github.workspace }}/lib/external/pcre2_build/
+          ${{ github.workspace }}/lib/external/libpcre2-8.a
+        key: ${{ runner.os }}-pcre2-${{ hashFiles('**/lib/external/pcre2_build/**', '**/lib/external/libpcre2-8.a') }}
         restore-keys: |
           ${{ runner.os }}-pcre2-
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 	ignore = dirty
 	shallow = true
 [submodule "lib/stdlib/pcre2"]
-	path = lib/stdlib/pcre2
+	path = lib/external/pcre2
 	url = https://github.com/PCRE2Project/pcre2.git
 	ignore = dirty
 	shallow = true

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ external: $(OUT_DIR)
 	@echo "building all external libraries"
 	cd $(EXT_DIR) ; '$(MAKE)' all
 	@if [ -f $(EXT_DIR)$(EXT_BIN_PCRE2) ]; then \
-		@echo copying $(EXT_DIR)$(EXT_BIN_PCRE2) to $(LIB_DIR_OUT)$(EXT_BIN_PCRE2); \
+		echo copying $(EXT_DIR)$(EXT_BIN_PCRE2) to $(LIB_DIR_OUT)$(EXT_BIN_PCRE2); \
 		$(CP) $(EXT_DIR)$(EXT_BIN_PCRE2) $(LIB_DIR_OUT)$(EXT_BIN_PCRE2); \
 	fi
 	@echo copying $(PCRE2_DIR) to $(STD_DIR_OUT)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CMD_DIR = ./cmd/
 STD_DIR = ./lib/stdlib/
 RUN_DIR = ./lib/runtime/
+EXT_DIR = ./lib/external/
 
 DDP_SETUP_BUILD_DIR = $(CMD_DIR)ddp-setup/build/
 
@@ -8,8 +9,8 @@ KDDP_BIN = ""
 DDP_SETUP_BIN = ""
 
 STD_BIN = libddpstdlib.a
-STD_BIN_PCRE2 = libpcre2-8.a
-PCRE2_DIR = $(STD_DIR)pcre2/
+EXT_BIN_PCRE2 = libpcre2-8.a
+PCRE2_DIR = $(EXT_DIR)pcre2/
 STD_BIN_DEBUG = $(STD_BIN:.a=debug.a)
 RUN_BIN = libddpruntime.a
 RUN_BIN_DEBUG = $(RUN_BIN:.a=debug.a)
@@ -64,9 +65,9 @@ SHELL = /bin/bash
 
 .PHONY = all clean clean-outdir debug kddp stdlib stdlib-debug runtime runtime-debug test test-memory checkout-llvm llvm help test-complete test-with-optimizations coverage
 
-all: $(OUT_DIR) kddp runtime stdlib ddp-setup ## compiles kdddp, the runtime, the stdlib and ddp-setup into the build/DDP/ directory 
+all: $(OUT_DIR) kddp runtime stdlib external ddp-setup ## compiles kdddp, the runtime, the stdlib and ddp-setup into the build/DDP/ directory 
 
-debug: $(OUT_DIR) kddp runtime-debug stdlib-debug ## same as all but the runtime and stdlib print debugging information
+debug: $(OUT_DIR) kddp runtime-debug stdlib-debug external ## same as all but the runtime and stdlib print debugging information
 
 kddp: $(OUT_DIR) ## compiles kddp into build/DDP/bin/
 	@echo "building kddp"
@@ -83,30 +84,18 @@ stdlib: $(OUT_DIR) ## compiles the stdlib and the Duden into build/DDP/lib/stdli
 	@echo "building the ddp-stdlib"
 	cd $(STD_DIR) ; '$(MAKE)'
 	$(CP) $(STD_DIR)$(STD_BIN) $(LIB_DIR_OUT)$(STD_BIN)
-	@if [ -f $(STD_DIR)$(STD_BIN_PCRE2) ]; then \
-		$(CP) $(STD_DIR)$(STD_BIN_PCRE2) $(LIB_DIR_OUT)$(STD_BIN_PCRE2); \
-	fi
 	$(CP) $(STD_DIR)include/ $(STD_DIR_OUT)
 	$(CP) $(STD_DIR)source/ $(STD_DIR_OUT)
 	$(CP) $(STD_DIR)Duden/ $(OUT_DIR)
-	@if [ -d $(PCRE2_DIR) ]; then \
-		$(CP) $(PCRE2_DIR) $(STD_DIR_OUT); \
-	fi
 	$(CP) $(STD_DIR)Makefile $(STD_DIR_OUT)Makefile
 
 stdlib-debug: $(OUT_DIR) ## same as stdlib but will print debugging information
 	@echo "building the ddp-stdlib in debug mode"
 	cd $(STD_DIR) ; '$(MAKE)' debug
 	$(CP) $(STD_DIR)$(STD_BIN_DEBUG) $(LIB_DIR_OUT)$(STD_BIN)
-	@if [ -f $(STD_DIR)$(STD_BIN_PCRE2) ]; then \
-		$(CP) $(STD_DIR)$(STD_BIN_PCRE2) $(LIB_DIR_OUT)$(STD_BIN_PCRE2); \
-	fi
 	$(CP) $(STD_DIR)include/ $(STD_DIR_OUT)
 	$(CP) $(STD_DIR)source/ $(STD_DIR_OUT)
 	$(CP) $(STD_DIR)Duden/ $(OUT_DIR)
-	@if [ -d $(PCRE2_DIR) ]; then \
-		$(CP) $(PCRE2_DIR) $(STD_DIR_OUT); \
-	fi
 	$(CP) $(STD_DIR)Makefile $(STD_DIR_OUT)Makefile
 
 runtime: $(OUT_DIR) ## compiles the runtime into build/DDP/lib/stdlib
@@ -127,6 +116,18 @@ runtime-debug: $(OUT_DIR) ## same as runtime but prints debugging information
 	$(CP) $(RUN_DIR)include/ $(RUN_DIR_OUT)
 	$(CP) $(RUN_DIR)source/ $(RUN_DIR_OUT)
 	$(CP) $(RUN_DIR)Makefile $(RUN_DIR_OUT)Makefile
+
+external: $(OUT_DIR)
+	@echo "building all external libraries"
+	cd $(EXT_DIR) ; '$(MAKE)' all
+	@if [ -f $(EXT_DIR)$(EXT_BIN_PCRE2) ]; then \
+		@echo copying $(EXT_DIR)$(EXT_BIN_PCRE2) to $(LIB_DIR_OUT)$(EXT_BIN_PCRE2); \
+		$(CP) $(EXT_DIR)$(EXT_BIN_PCRE2) $(LIB_DIR_OUT)$(EXT_BIN_PCRE2); \
+	fi
+	@echo copying $(PCRE2_DIR) to $(STD_DIR_OUT)
+	@if [ -d $(PCRE2_DIR) ]; then \
+		$(CP) $(PCRE2_DIR) $(STD_DIR_OUT); \
+	fi
 
 $(OUT_DIR): LICENSE README.md ## creates build/DDP/, build/DDP/bin/, build/DDP/lib/, ... and copies the LICENSE and README.md
 	@echo "creating output directories"
@@ -151,7 +152,7 @@ clean-outdir: ## deletes build/DDP/
 	$(RM) $(OUT_DIR)
 
 clean-all: clean
-	cd $(STD_DIR) ; $(MAKE) clean-all
+	cd $(EXT_DIR) ; '$(MAKE)' clean
 
 checkout-llvm: ## clones the llvm-project submodule
 # clone the submodule

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ ddp-setup: $(OUT_DIR) ## compiles ddp-setup into build/DDP/bin/
 	cd $(CMD_DIR) ; '$(MAKE)' ddp-setup
 	$(CP) $(CMD_DIR)ddp-setup/build/$(DDP_SETUP_BIN) $(DDP_SETUP_DIR_OUT)$(DDP_SETUP_BIN)
 
-stdlib: $(OUT_DIR) ## compiles the stdlib and the Duden into build/DDP/lib/stdlib and build/DDP/Duden
+stdlib: $(OUT_DIR) external ## compiles the stdlib and the Duden into build/DDP/lib/stdlib and build/DDP/Duden
 	@echo "building the ddp-stdlib"
 	cd $(STD_DIR) ; '$(MAKE)'
 	$(CP) $(STD_DIR)$(STD_BIN) $(LIB_DIR_OUT)$(STD_BIN)
@@ -89,7 +89,7 @@ stdlib: $(OUT_DIR) ## compiles the stdlib and the Duden into build/DDP/lib/stdli
 	$(CP) $(STD_DIR)Duden/ $(OUT_DIR)
 	$(CP) $(STD_DIR)Makefile $(STD_DIR_OUT)Makefile
 
-stdlib-debug: $(OUT_DIR) ## same as stdlib but will print debugging information
+stdlib-debug: $(OUT_DIR) external ## same as stdlib but will print debugging information
 	@echo "building the ddp-stdlib in debug mode"
 	cd $(STD_DIR) ; '$(MAKE)' debug
 	$(CP) $(STD_DIR)$(STD_BIN_DEBUG) $(LIB_DIR_OUT)$(STD_BIN)

--- a/lib/external/.gitignore
+++ b/lib/external/.gitignore
@@ -1,0 +1,7 @@
+*.o
+*.lib
+*.a
+*.depend
+/.cache/
+compile_commands.json
+/pcre2_build/*

--- a/lib/external/Makefile
+++ b/lib/external/Makefile
@@ -4,6 +4,8 @@
 RM = rm -f
 MKDIR = mkdir -p
 
+CC = gcc
+
 PCRE2_CMAKE_BUILD_TOOL=$(MAKE)
 PCRE2_OUT_FILE_NAME = libpcre2-8.a
 PCRE2_DIR = ./pcre2_build/
@@ -18,7 +20,7 @@ ifneq ($(OS),Windows_NT)
 $(PCRE2_OUT_FILE_NAME):
 	@echo "pcre2 is already provided on linux systems"
 else
-$(PCRE2_OUT_FILE_NAME): | checkout-pcre2
+$(PCRE2_OUT_FILE_NAME): | checkout-submodules
 	@echo "building pcre2"
 	$(MKDIR) $(PCRE2_DIR)
 	cmake -S./pcre2/ -B$(PCRE2_DIR) -DCMAKE_BUILD_TYPE=Release -G"MinGW Makefiles" -DCMAKE_C_COMPILER=$(CC) -DCMAKE_COLOR_MAKEFILE=OFF

--- a/lib/external/Makefile
+++ b/lib/external/Makefile
@@ -1,0 +1,35 @@
+.PHONY = all clean checkout-submodules
+.DEFAULT_GOAL = all
+
+RM = rm -f
+MKDIR = mkdir -p
+
+PCRE2_CMAKE_BUILD_TOOL=$(MAKE)
+PCRE2_OUT_FILE_NAME = libpcre2-8.a
+PCRE2_DIR = ./pcre2_build/
+
+SUBMODULES = pcre2
+
+checkout-submodules:
+	git submodule update --init $(SUBMODULES)
+
+# pcre2 only needs to be compiled on windows
+ifneq ($(OS),Windows_NT)
+$(PCRE2_OUT_FILE_NAME):
+	@echo "pcre2 is already provided on linux systems"
+else
+$(PCRE2_OUT_FILE_NAME): | checkout-pcre2
+	@echo "building pcre2"
+	$(MKDIR) $(PCRE2_DIR)
+	cmake -S./pcre2/ -B$(PCRE2_DIR) -DCMAKE_BUILD_TYPE=Release -G"MinGW Makefiles" -DCMAKE_C_COMPILER=$(CC) -DCMAKE_COLOR_MAKEFILE=OFF
+	cd $(PCRE2_DIR) && $(PCRE2_CMAKE_BUILD_TOOL) pcre2-8-static
+	cp $(PCRE2_DIR)$(PCRE2_OUT_FILE_NAME) .
+endif
+
+all: checkout-submodules $(PCRE2_OUT_FILE_NAME)
+
+clean:
+ifeq ($(OS),Windows_NT)
+	$(RM) $(PCRE2_OUT_FILE_NAME)
+	cd $(PCRE2_DIR) ; $(PCRE2_CMAKE_BUILD_TOOL) clean
+endif

--- a/lib/stdlib/Makefile
+++ b/lib/stdlib/Makefile
@@ -1,9 +1,8 @@
 OUT_FILE_NAME = libddpstdlib.a
 OUT_FILE_NAME_DEBUG = $(OUT_FILE_NAME:.a=debug.a)
-PCRE2_DIR = ./pcre2_build/
-PCRE2_OUT_FILE_NAME = libpcre2-8.a
+PCRE2_DIR = ../external/pcre2/
 
-.PHONY = all clean debug checkout-pcre2
+.PHONY = all clean debug
 .DEFAULT_GOAL = all
 
 CC = gcc
@@ -15,8 +14,6 @@ AR = ar rcs
 RM = rm -f
 MKDIR = mkdir -p
 
-PCRE2_CMAKE_BUILD_TOOL=$(MAKE)
-
 # these wildcards work only to depth 1
 # so include/utf8/utf8.c is matched but include/utf8/test_dir/test.c would NOT be matched
 # if you want to add more subdirectories, simply add a nesting more here (aka: include/*/*/*.h)
@@ -26,26 +23,6 @@ SRCS = $(wildcard source/DDP/*.c source/DDP/*/*.c)
 RUNTIME_SRCS = $(wildcard ../runtime/source/DDP/*.c ../runtime/source/DDP/*/*.c)
 OBJS = $(SRCS:.c=.o)
 OBJS_DEBUG = $(OBJS:.o=_debug.o)
-
-checkout-pcre2:
-ifeq ($(shell git submodule status pcre2 | cut -c1 | grep --quiet '-' && echo $$?), 0)
-	cd ../../ && git submodule update --init lib/stdlib/pcre2
-else
-	@echo "pcre2 already present"
-endif
-
-# pcre2 only needs to be compiled on windows
-ifneq ($(OS),Windows_NT)
-$(PCRE2_OUT_FILE_NAME):
-	@echo "pcre2 is already provided on linux systems"
-else
-$(PCRE2_OUT_FILE_NAME): | checkout-pcre2
-	@echo "building pcre2"
-	$(MKDIR) $(PCRE2_DIR)
-	cmake -S./pcre2/ -B$(PCRE2_DIR) -DCMAKE_BUILD_TYPE=Release -G"MinGW Makefiles" -DCMAKE_C_COMPILER=$(CC) -DCMAKE_COLOR_MAKEFILE=OFF
-	cd $(PCRE2_DIR) && $(PCRE2_CMAKE_BUILD_TOOL) pcre2-8-static
-	cp $(PCRE2_DIR)$(PCRE2_OUT_FILE_NAME) .
-endif
 
 %.o: %.c
 	$(CC) $(CCFLAGS) $(INC) -o $@ $<
@@ -74,12 +51,6 @@ compile_commands.json: $(SRCS) $(HEADERS)
 
 clean:
 	$(RM) $(OBJS) $(OBJS_DEBUG) $(OUT_FILE_NAME) $(OUT_FILE_NAME_DEBUG) .depend
-
-clean-all: clean
-	$(RM) $(PCRE2_OUT_FILE_NAME)
-	@if [ -d $(PCRE2_DIR) ]; then \
-		cd $(PCRE2_DIR) && '$(PCRE2_CMAKE_BUILD_TOOL)' clean; \
-	fi
 
 .depend: $(SRCS) $(RUNTIME_SRCS) $(HEADERS) $(RUNTIME_HEADERS)
 	$(CC) -MM $(INC) $(SRCS) > .depend

--- a/lib/stdlib/Makefile
+++ b/lib/stdlib/Makefile
@@ -1,6 +1,6 @@
 OUT_FILE_NAME = libddpstdlib.a
 OUT_FILE_NAME_DEBUG = $(OUT_FILE_NAME:.a=debug.a)
-PCRE2_DIR = ../external/pcre2/
+PCRE2_DIR = ../external/pcre2_build/
 
 .PHONY = all clean debug
 .DEFAULT_GOAL = all


### PR DESCRIPTION
External libraries are now all in the directory lib/external and can be built using `make external`.
when doing a `make clean` they are not cleaned as they don't change often.