### PR TITLE
Github-Actions fix

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,13 +29,8 @@ jobs:
       with:
         go-version-file: go.mod
         cache-key-suffix: kompilierer
-        
-    - name: Setup LLVM
-      if: runner.os == 'Linux'
-      run: sudo apt install llvm-12
 
     - name: Cache LLVM
-      if: runner.os == 'Windows'
       id: cache-llvm
       uses: actions/cache@v4
       with:
@@ -45,7 +40,7 @@ jobs:
           ${{ runner.os }}-llvm-build-
 
     - name: Download Prebuilt LLVM
-      if: runner.os == 'Windows' && steps.cache-llvm.outputs.cache-hit != 'true'
+      if: steps.cache-llvm.outputs.cache-hit != 'true'
       run: |
         curl -L -o ./llvm_build.tar.gz https://github.com/DDP-Projekt/Kompilierer/releases/download/llvm-binaries/llvm_build-mingw-12.2.0-x86_64-ucrt-posix-seh.tar.gz
         mkdir -p ./llvm_build/

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -39,10 +39,10 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-llvm-build-
 
-    - name: Download Prebuilt LLVM
+    - name: Setup LLVM
       if: steps.cache-llvm.outputs.cache-hit != 'true'
       run: |
-        curl -L -o ./llvm_build.tar.gz https://github.com/DDP-Projekt/Kompilierer/releases/download/llvm-binaries/llvm_build-mingw-12.2.0-x86_64-ucrt-posix-seh.tar.gz
+        curl -L -o ./llvm_build.tar.gz https://github.com/DDP-Projekt/Kompilierer/releases/download/llvm-binaries/llvm_build-${{ runner.os == 'Windows' && 'mingw-12.2.0-x86_64-ucrt-posix-seh' || 'linux-11.4.0-x86_64' }}.tar.gz
         mkdir -p ./llvm_build/
         tar -xzf ./llvm_build.tar.gz -C ./ --force-local
         rm ./llvm_build.tar.gz

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -86,6 +86,24 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+
+    - name: Cache LLVM
+      id: cache-llvm
+      uses: actions/cache@v4
+      with:
+        path: ${{ github.workspace }}/llvm_build/
+        key: ${{ runner.os }}-llvm-build-${{ hashFiles('**/Makefile', '**/cmd/Makefile') }}
+        restore-keys: |
+          ${{ runner.os }}-llvm-build-
+
+    - name: Setup LLVM
+      if: steps.cache-llvm.outputs.cache-hit != 'true'
+      run: |
+        curl -L -o ./llvm_build.tar.gz https://github.com/DDP-Projekt/Kompilierer/releases/download/llvm-binaries/llvm_build-${{ runner.os == 'Windows' && 'mingw-12.2.0-x86_64-ucrt-posix-seh' || 'linux-11.4.0-x86_64' }}.tar.gz
+        mkdir -p ./llvm_build/
+        tar -xzf ./llvm_build.tar.gz -C ./ --force-local
+        rm ./llvm_build.tar.gz
+
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above
     # to set the build mode to "manual" for that language. Then modify this step
@@ -94,7 +112,6 @@ jobs:
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'
       run: |
-        sudo apt install llvm-12
         sudo locale-gen de_DE.UTF-8
         make -j$(nproc)
 


### PR DESCRIPTION
Das package llvm-12 ist in einer neueren Ubuntu version wohl nicht mehr vorhanden, deshalb sorgt diese PR dafür, dass wir immer unsere pre-built binaries benutzen.

Irgendwann müssen wir LLVM mal updaten, aber das wird recht aufwändig, darum erstmal dieser fix.

Failing Action run: https://github.com/DDP-Projekt/Kompilierer/actions/runs/12429781631