### PR TITLE
Konstante

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Der Changelog von DDP. Sortiert nach Release.
 
 ## In Entwicklung
 
+- [Neu] Konstante hinzugefügt
 - [Neu] Bei Iterierenden Schleifen kann man jetzt einen Index angeben (Für jeden Typname t mit Index i in ...)
 - [Anders] Der Kompilierer benutzt jetzt LLVM Version 14.0.0 (anstatt 12.0.0)
 - [Neu] Duden/Befehlszeile zum Arbeiten mit Befehlszeilenargumenten

--- a/examples/Fizzbuzz.ddp
+++ b/examples/Fizzbuzz.ddp
@@ -1,6 +1,6 @@
 Binde "Duden/Ausgabe" ein.
 Binde Ist_Teilbar aus "Duden/Mathe" ein.
-Binde Zahl_Eins, Zahl_Drei, Zahl_Fünf und Zahl_Hundert aus "Duden/Zahlen" ein.
+Binde Zahl_Eins, drei, fünf und hundert aus "Duden/Zahlen" ein.
 
 Für jede Zahl i von eins bis hundert, mache:
     Wenn i durch drei teilbar ist und i durch fünf teilbar ist, Schreibe den Text "FizzBuzz" auf eine Zeile.

--- a/lib/stdlib/Duden/Dateisystem.ddp
+++ b/lib/stdlib/Duden/Dateisystem.ddp
@@ -158,13 +158,13 @@ Und kann so benutzt werden:
 	!!! Müssen mit den C Flags übereinstimmen !!!
 ]
 
-Die öffentliche Zahl MODUS_NUR_LESEN ist 1.
-Die öffentliche Zahl MODUS_NUR_SCHREIBEN ist 2.
-Die öffentliche Zahl MODUS_LESEN_SCHREIBEN ist 4.
+Die öffentliche Konstante MODUS_NUR_LESEN ist 1.
+Die öffentliche Konstante MODUS_NUR_SCHREIBEN ist 2.
+Die öffentliche Konstante MODUS_LESEN_SCHREIBEN ist 4.
 
-Die öffentliche Zahl MODUS_ERSTELLEN ist 8.
-Die öffentliche Zahl MODUS_ANHAENGEN ist 16.
-Die öffentliche Zahl MODUS_TRUNKIEREN ist 32.
+Die öffentliche Konstante MODUS_ERSTELLEN ist 8.
+Die öffentliche Konstante MODUS_ANHAENGEN ist 16.
+Die öffentliche Konstante MODUS_TRUNKIEREN ist 32.
 
 [
 	Eine Kombination, die Daten über eine Datei enthält, von der gelesen oder in die geschrieben werden kann.

--- a/lib/stdlib/Duden/Komprimierung.ddp
+++ b/lib/stdlib/Duden/Komprimierung.ddp
@@ -1,11 +1,11 @@
 Binde "Duden/Fehlerbehandlung" ein.
 
-Die öffentliche Zahl ZIP ist 5242880.
-Die öffentliche Zahl GZIP ist 3145777.
-Die öffentliche Zahl XZ ist 3145782.
-Die öffentliche Zahl BZIP2 ist 3145778.
-Die öffentliche Zahl LZ4 ist 3145789.
-Die öffentliche Zahl SevenZip ist 14680064.
+Die öffentliche Konstante ZIP ist 5242880.
+Die öffentliche Konstante GZIP ist 3145777.
+Die öffentliche Konstante XZ ist 3145782.
+Die öffentliche Konstante BZIP2 ist 3145778.
+Die öffentliche Konstante LZ4 ist 3145789.
+Die öffentliche Konstante SevenZip ist 14680064.
 
 [
 	Verpacken

--- a/lib/stdlib/Duden/Mathe.ddp
+++ b/lib/stdlib/Duden/Mathe.ddp
@@ -2,38 +2,26 @@
 	Gibt den Wert von der Kreiszahl "PI" (π) mit 15 Nachkommastellen zurück:
 	3,141592653589793
 ]
-Die öffentliche Funktion PI gibt eine Kommazahl zurück, macht:
-	Gib 3,141592653589793 zurück.
-Und kann so benutzt werden:
-	"PI"
+Die öffentliche Konstante PI ist 3,141592653589793.
 
 [
 	Gibt den Wert der Eulerschen Zahl "E" mit 15 Nachkommastellen zurück:
 	2,718281828459045
 ]
-Die öffentliche Funktion E gibt eine Kommazahl zurück, macht:
-	Gib 2,718281828459045 zurück.
-Und kann so benutzt werden:
-	"E"
+Die öffentliche Konstante E ist 2,718281828459045.
 
 [
 	Gibt den Wert der alternativen Kreiszahl "TAU" (τ) mit 15 Nachkommastellen zurück:
 	6,283185307179586
 	Es entspricht exakt den Wert von 2 mal PI.
 ]
-Die öffentliche Funktion TAU gibt eine Kommazahl zurück, macht:
-	Gib 6,283185307179586 zurück.
-Und kann so benutzt werden:
-	"TAU"
+Die öffentliche Konstante TAU ist 6,283185307179586.
 
 [
 	Gibt den Wert des Goldenen Schittes "PHI" (Φ) mit 15 Nachkommastellen zurück:
 	1,618033988749895
 ]
-Die öffentliche Funktion PHI gibt eine Kommazahl zurück, macht:
-	Gib 1,618033988749895 zurück.
-Und kann so benutzt werden:
-	"PHI"
+Die öffentliche Konstante PHI ist 1,618033988749895.
 
 [
 	Wenn a >= b ist wird a zurück gegeben.

--- a/lib/stdlib/Duden/Zahlen.ddp
+++ b/lib/stdlib/Duden/Zahlen.ddp
@@ -74,165 +74,108 @@ Die öffentliche Funktion KeineZahl gibt eine Kommazahl zurück, macht:
 Und kann so benutzt werden:
 	"keine Zahl"
 
-[
-	Gibt 0 zurück.
-]
-Die öffentliche Funktion Zahl_Null gibt eine Zahl zurück, macht:
-	Gib 0 zurück.
-Und kann so benutzt werden:
-	"Null" oder "null"
+Die öffentliche Konstante Null ist 0.
+Die öffentliche Konstante null ist 0.
 
-[
-	Gibt 1 zurück.
-]
 Die öffentliche Funktion Zahl_Eins gibt eine Zahl zurück, macht:
+	[ Funktion, weil "ein" ein reservierter Token ist ]
 	Gib 1 zurück.
 Und kann so benutzt werden:
-	"Eins", "eins", "ein", "erste", "ersten"
+	"ein", "Eins", "eins", "erste", "ersten"
 
-[
-	Gibt 2 zurück.
-]
-Die öffentliche Funktion Zahl_Zwei gibt eine Zahl zurück, macht:
-	Gib 2 zurück.
-Und kann so benutzt werden:
-	"Zwei", "zwei", "zweite", "zweiten"
+Die öffentliche Konstante Zwei ist 2.
+Die öffentliche Konstante zwei ist 2.
+Die öffentliche Konstante zweite ist 2.
+Die öffentliche Konstante zweiten ist 2.
 
-[
-	Gibt 3 zurück.
-]
-Die öffentliche Funktion Zahl_Drei gibt eine Zahl zurück, macht:
-	Gib 3 zurück.
-Und kann so benutzt werden:
-	"Drei", "drei", "dritte", "dritten"
+Die öffentliche Konstante Drei ist 3.
+Die öffentliche Konstante drei ist 3.
+Die öffentliche Konstante dritte ist 3.
+Die öffentliche Konstante dritten ist 3.
 
-[
-	Gibt 4 zurück.
-]
-Die öffentliche Funktion Zahl_Vier gibt eine Zahl zurück, macht:
-	Gib 4 zurück.
-Und kann so benutzt werden:
-	"Vier", "vier", "vierte", "vierten"
+Die öffentliche Konstante Vier ist 4.
+Die öffentliche Konstante vier ist 4.
+Die öffentliche Konstante vierte ist 4.
+Die öffentliche Konstante vierten ist 4.
 
-[
-	Gibt 5 zurück.
-]
-Die öffentliche Funktion Zahl_Fünf gibt eine Zahl zurück, macht:
-	Gib 5 zurück.
-Und kann so benutzt werden:
-	"Fünf", "fünf", "fünfte", "fünften"
+Die öffentliche Konstante Fünf ist 5.
+Die öffentliche Konstante fünf ist 5.
+Die öffentliche Konstante fünfte ist 5.
+Die öffentliche Konstante fünften ist 5.
 
-[
-	Gibt 6 zurück.
-]
-Die öffentliche Funktion Zahl_Sechs gibt eine Zahl zurück, macht:
-	Gib 6 zurück.
-Und kann so benutzt werden:
-	"Sechs", "sechs", "sechste", "sechsten"
+Die öffentliche Konstante Sechs ist 6.
+Die öffentliche Konstante sechs ist 6.
+Die öffentliche Konstante sechste ist 6.
+Die öffentliche Konstante sechsten ist 6.
 
-[
-	Gibt 7 zurück.
-]
-Die öffentliche Funktion Zahl_Sieben gibt eine Zahl zurück, macht:
-	Gib 7 zurück.
-Und kann so benutzt werden:
-	"Sieben", "sieben", "siebte", "siebten"
+Die öffentliche Konstante Sieben ist 7.
+Die öffentliche Konstante sieben ist 7.
+Die öffentliche Konstante siebte ist 7.
+Die öffentliche Konstante siebten ist 7.
 
-[
-	Gibt 8 zurück.
-]
-Die öffentliche Funktion Zahl_Acht gibt eine Zahl zurück, macht:
-	Gib 8 zurück.
-Und kann so benutzt werden:
-	"Acht", "acht", "achte", "achten"
+Die öffentliche Konstante Acht ist 8.
+Die öffentliche Konstante acht ist 8.
+Die öffentliche Konstante achte ist 8.
+Die öffentliche Konstante achten ist 8.
 
-[
-	Gibt 9 zurück.
-]
-Die öffentliche Funktion Zahl_Neun gibt eine Zahl zurück, macht:
-	Gib 9 zurück.
-Und kann so benutzt werden:
-	"Neun", "neun", "neunte", "neunten"
+Die öffentliche Konstante Neun ist 9.
+Die öffentliche Konstante neun ist 9.
+Die öffentliche Konstante neunte ist 9.
+Die öffentliche Konstante neunten ist 9.
 
-[
-	Gibt 10 zurück.
-]
-Die öffentliche Funktion Zahl_Zehn gibt eine Zahl zurück, macht:
-	Gib 10 zurück.
-Und kann so benutzt werden:
-	"Zehn", "zehn", "zehnte", "zehnten"
+Die öffentliche Konstante Zehn ist 10.
+Die öffentliche Konstante zehn ist 10.
+Die öffentliche Konstante zehnte ist 10.
+Die öffentliche Konstante zehnten ist 10.
 
-[
-	Gibt 11 zurück.
-]
-Die öffentliche Funktion Zahl_Elf gibt eine Zahl zurück, macht:
-	Gib 11 zurück.
-Und kann so benutzt werden:
-	"Elf", "elf", "elfte", "elften"
+Die öffentliche Konstante Elf ist 11.
+Die öffentliche Konstante elf ist 11.
+Die öffentliche Konstante elfte ist 11.
+Die öffentliche Konstante elften ist 11.
 
-[
-	Gibt 12 zurück.
-]
-Die öffentliche Funktion Zahl_Zwölf gibt eine Zahl zurück, macht:
-	Gib 12 zurück.
-Und kann so benutzt werden:
-	"Zwölf", "zwölf", "zwölfte", "zwölften"
+Die öffentliche Konstante Zwölf ist 12.
+Die öffentliche Konstante zwölf ist 12.
+Die öffentliche Konstante zwölfte ist 12.
+Die öffentliche Konstante zwölften ist 12.
 
-[
-	Gibt 100 zurück.
-]
-Die öffentliche Funktion Zahl_Hundert gibt eine Zahl zurück, macht:
-	Gib 100 zurück.
-Und kann so benutzt werden:
-	"Einhundert", "Hundert", "hundert", "hunderte", "hunderten"
+Die öffentliche Konstante Einhundert ist 100.
+Die öffentliche Konstante Hundert ist 100.
+Die öffentliche Konstante hundert ist 100.
+Die öffentliche Konstante hunderte ist 100.
+Die öffentliche Konstante hunderten ist 100.
 
-[
-	Gibt 1000 zurück.
-]
-Die öffentliche Funktion Zahl_Tausend gibt eine Zahl zurück, macht:
-	Gib 1000 zurück.
-Und kann so benutzt werden:
-	"Eintausend", "Tausend", "tausend", "tausenste", "tausensten"
+Die öffentliche Konstante Eintausend ist 1000.
+Die öffentliche Konstante Tausend ist 1000.
+Die öffentliche Konstante tausend ist 1000.
+Die öffentliche Konstante tausenste ist 1000.
+Die öffentliche Konstante tausensten ist 1000.
 
-[
-	Gibt 10000 zurück.
-]
-Die öffentliche Funktion Zahl_Zehntausend gibt eine Zahl zurück, macht:
-	Gib 10000 zurück.
-Und kann so benutzt werden:
-	"Zehntausend" oder "zehntausend"
+Die öffentliche Konstante Zehntausend ist 10000.
+Die öffentliche Konstante zehntausend ist 10000.
 
-[
-	Gibt 100000 zurück.
-]
-Die öffentliche Funktion Zahl_Hunderttausend gibt eine Zahl zurück, macht:
-	Gib 100000 zurück.
-Und kann so benutzt werden:
-	"Einhunderttausend" oder "einhunderttausend"
+Die öffentliche Konstante Einhunderttausend ist 100000.
+Die öffentliche Konstante einhunderttausend ist 100000.
 
+Die öffentliche Konstante Million ist 1000000.
 [
 	Gibt 1000000 zurück.
 ]
-Die öffentliche Funktion Zahl_Million gibt eine Zahl zurück, macht:
-	Gib 1000000 zurück.
+Die öffentliche Funktion Zahl_Million mit dem Parameter n vom Typ Zahl, gibt eine Zahl zurück, macht:
+	Gib n mal 1000000 zurück.
 Und kann so benutzt werden:
-	"eine Million" oder "Million"
+	"<n> Million"
 
 [
 	Gibt 0,5 zurück.
 ]
-Die öffentliche Funktion Zahl_Halb gibt eine Kommazahl zurück, macht:
-	Gib 0,5 zurück.
-Und kann so benutzt werden:
-	"einhalb" oder "halb"
+Die öffentliche Konstante einhalb ist 0,5.
+Die öffentliche Konstante halb ist 0,5.
 
 [
 	Gibt 1,5 zurück.
 ]
-Die öffentliche Funktion Zahl_Anderthalb gibt eine Kommazahl zurück, macht:
-	Gib 1,5 zurück.
-Und kann so benutzt werden:
-	"anderthalb" oder "eineinhalb"
+Die öffentliche Konstante anderthalb ist 1,5.
+Die öffentliche Konstante eineinhalb ist 1,5.
 
 [
 	Gibt <n> durch 2 zurück.

--- a/src/ast/annotators/const_func_param.go
+++ b/src/ast/annotators/const_func_param.go
@@ -129,7 +129,7 @@ func doesReferenceVarMutable(expr ast.Expression, decls []*ast.VarDecl) []*ast.V
 	switch ass := ass.(type) {
 	case *ast.Ident:
 		for _, decl := range decls {
-			if decl == ass.Declaration {
+			if decl == *ass.Declaration {
 				return []*ast.VarDecl{decl}
 			}
 		}

--- a/src/ast/annotators/const_func_param.go
+++ b/src/ast/annotators/const_func_param.go
@@ -129,7 +129,7 @@ func doesReferenceVarMutable(expr ast.Expression, decls []*ast.VarDecl) []*ast.V
 	switch ass := ass.(type) {
 	case *ast.Ident:
 		for _, decl := range decls {
-			if decl == *ass.Declaration {
+			if decl == ass.Declaration {
 				return []*ast.VarDecl{decl}
 			}
 		}

--- a/src/ast/declarations.go
+++ b/src/ast/declarations.go
@@ -15,14 +15,13 @@ type (
 	}
 
 	ConstDecl struct {
-		Range           token.Range
-		Mod             *Module       // the module in which the variable was declared
-		CommentTok      *token.Token  // optional comment (also contained in ast.Comments)
-		Type            ddptypes.Type // type of the variable
-		NameTok         token.Token   // identifier name
-		Val             Expression
-		IsPublic        bool // wether the function is marked with öffentliche
-		IsExternVisible bool // wether the variable is marked as extern visible
+		Range      token.Range
+		Mod        *Module       // the module in which the variable was declared
+		CommentTok *token.Token  // optional comment (also contained in ast.Comments)
+		Type       ddptypes.Type // type of the variable
+		NameTok    token.Token   // identifier name
+		Val        Expression
+		IsPublic   bool // wether the function is marked with öffentliche
 	}
 
 	VarDecl struct {

--- a/src/ast/declarations.go
+++ b/src/ast/declarations.go
@@ -14,6 +14,17 @@ type (
 		Mod *Module
 	}
 
+	ConstDecl struct {
+		Range           token.Range
+		Mod             *Module       // the module in which the variable was declared
+		CommentTok      *token.Token  // optional comment (also contained in ast.Comments)
+		Type            ddptypes.Type // type of the variable
+		NameTok         token.Token   // identifier name
+		Val             Expression
+		IsPublic        bool // wether the function is marked with öffentliche
+		IsExternVisible bool // wether the variable is marked as extern visible
+	}
+
 	VarDecl struct {
 		Range           token.Range
 		CommentTok      *token.Token  // optional comment (also contained in ast.Comments)
@@ -92,6 +103,7 @@ type (
 )
 
 func (decl *BadDecl) node()       {}
+func (decl *ConstDecl) node()     {}
 func (decl *VarDecl) node()       {}
 func (decl *FuncDecl) node()      {}
 func (decl *FuncDef) node()       {}
@@ -100,6 +112,7 @@ func (decl *TypeAliasDecl) node() {}
 func (decl *TypeDefDecl) node()   {}
 
 func (decl *BadDecl) String() string       { return "BadDecl" }
+func (decl *ConstDecl) String() string     { return "ConstDecl" }
 func (decl *VarDecl) String() string       { return "VarDecl" }
 func (decl *FuncDecl) String() string      { return "FuncDecl" }
 func (decl *FuncDef) String() string       { return "FuncDef" }
@@ -108,6 +121,7 @@ func (decl *TypeAliasDecl) String() string { return "TypeAliasDecl" }
 func (decl *TypeDefDecl) String() string   { return "TypeDefDecl" }
 
 func (decl *BadDecl) Token() token.Token       { return decl.Tok }
+func (decl *ConstDecl) Token() token.Token     { return decl.NameTok }
 func (decl *VarDecl) Token() token.Token       { return decl.NameTok }
 func (decl *FuncDecl) Token() token.Token      { return decl.Tok }
 func (decl *FuncDef) Token() token.Token       { return decl.Tok }
@@ -116,6 +130,7 @@ func (decl *TypeAliasDecl) Token() token.Token { return decl.Tok }
 func (decl *TypeDefDecl) Token() token.Token   { return decl.Tok }
 
 func (decl *BadDecl) GetRange() token.Range       { return decl.Err.Range }
+func (decl *ConstDecl) GetRange() token.Range     { return decl.Range }
 func (decl *VarDecl) GetRange() token.Range       { return decl.Range }
 func (decl *FuncDecl) GetRange() token.Range      { return decl.Range }
 func (decl *FuncDef) GetRange() token.Range       { return decl.Range }
@@ -124,6 +139,7 @@ func (decl *TypeAliasDecl) GetRange() token.Range { return decl.Range }
 func (decl *TypeDefDecl) GetRange() token.Range   { return decl.Range }
 
 func (decl *BadDecl) Accept(visitor FullVisitor) VisitResult    { return visitor.VisitBadDecl(decl) }
+func (decl *ConstDecl) Accept(visitor FullVisitor) VisitResult  { return visitor.VisitConstDecl(decl) }
 func (decl *VarDecl) Accept(visitor FullVisitor) VisitResult    { return visitor.VisitVarDecl(decl) }
 func (decl *FuncDecl) Accept(visitor FullVisitor) VisitResult   { return visitor.VisitFuncDecl(decl) }
 func (decl *FuncDef) Accept(visitor FullVisitor) VisitResult    { return visitor.VisitFuncDef(decl) }
@@ -137,6 +153,7 @@ func (decl *TypeDefDecl) Accept(visitor FullVisitor) VisitResult {
 }
 
 func (decl *BadDecl) declarationNode()       {}
+func (decl *ConstDecl) declarationNode()     {}
 func (decl *VarDecl) declarationNode()       {}
 func (decl *FuncDecl) declarationNode()      {}
 func (decl *FuncDef) statementNode()         {}
@@ -145,6 +162,7 @@ func (decl *TypeAliasDecl) declarationNode() {}
 func (decl *TypeDefDecl) declarationNode()   {}
 
 func (decl *BadDecl) Name() string       { return "" }
+func (decl *ConstDecl) Name() string     { return decl.NameTok.Literal }
 func (decl *VarDecl) Name() string       { return decl.NameTok.Literal }
 func (decl *FuncDecl) Name() string      { return decl.NameTok.Literal }
 func (decl *StructDecl) Name() string    { return decl.NameTok.Literal }
@@ -152,6 +170,7 @@ func (decl *TypeAliasDecl) Name() string { return decl.NameTok.Literal }
 func (decl *TypeDefDecl) Name() string   { return decl.NameTok.Literal }
 
 func (decl *BadDecl) Public() bool       { return false }
+func (decl *ConstDecl) Public() bool     { return decl.IsPublic }
 func (decl *VarDecl) Public() bool       { return decl.IsPublic }
 func (decl *FuncDecl) Public() bool      { return decl.IsPublic }
 func (decl *StructDecl) Public() bool    { return decl.IsPublic }
@@ -159,6 +178,7 @@ func (decl *TypeAliasDecl) Public() bool { return decl.IsPublic }
 func (decl *TypeDefDecl) Public() bool   { return decl.IsPublic }
 
 func (decl *BadDecl) Comment() *token.Token       { return nil }
+func (decl *ConstDecl) Comment() *token.Token     { return decl.CommentTok }
 func (decl *VarDecl) Comment() *token.Token       { return decl.CommentTok }
 func (decl *FuncDecl) Comment() *token.Token      { return decl.CommentTok }
 func (decl *StructDecl) Comment() *token.Token    { return decl.CommentTok }
@@ -166,6 +186,7 @@ func (decl *TypeAliasDecl) Comment() *token.Token { return decl.CommentTok }
 func (decl *TypeDefDecl) Comment() *token.Token   { return decl.CommentTok }
 
 func (decl *BadDecl) Module() *Module       { return decl.Mod }
+func (decl *ConstDecl) Module() *Module     { return decl.Mod }
 func (decl *VarDecl) Module() *Module       { return decl.Mod }
 func (decl *FuncDecl) Module() *Module      { return decl.Mod }
 func (decl *StructDecl) Module() *Module    { return decl.Mod }

--- a/src/ast/declarations.go
+++ b/src/ast/declarations.go
@@ -20,7 +20,7 @@ type (
 		CommentTok *token.Token  // optional comment (also contained in ast.Comments)
 		Type       ddptypes.Type // type of the variable
 		NameTok    token.Token   // identifier name
-		Val        Expression
+		Val        Literal
 		IsPublic   bool // wether the function is marked with öffentliche
 	}
 

--- a/src/ast/expressions.go
+++ b/src/ast/expressions.go
@@ -41,6 +41,10 @@ type (
 		Field *Ident      // the field name
 	}
 
+	Literal interface {
+		literal()
+	}
+
 	IntLit struct {
 		Literal token.Token
 		Value   int64
@@ -289,3 +293,10 @@ func (expr *StructLiteral) expressionNode() {}
 func (expr *Ident) assigneable()       {}
 func (expr *Indexing) assigneable()    {}
 func (expr *FieldAccess) assigneable() {}
+
+func (expr *IntLit) literal()    {}
+func (expr *FloatLit) literal()  {}
+func (expr *BoolLit) literal()   {}
+func (expr *CharLit) literal()   {}
+func (expr *StringLit) literal() {}
+func (expr *ListLit) literal()   {}

--- a/src/ast/expressions.go
+++ b/src/ast/expressions.go
@@ -22,7 +22,7 @@ type (
 		Literal token.Token
 		// the variable declaration this identifier refers to
 		// is set by the resolver, or nil if the name was not found
-		Declaration *Declaration
+		Declaration Declaration
 	}
 
 	// also exists as Binary expression for Literals

--- a/src/ast/expressions.go
+++ b/src/ast/expressions.go
@@ -22,7 +22,7 @@ type (
 		Literal token.Token
 		// the variable declaration this identifier refers to
 		// is set by the resolver, or nil if the name was not found
-		Declaration *VarDecl
+		Declaration *Declaration
 	}
 
 	// also exists as Binary expression for Literals

--- a/src/ast/expressions.go
+++ b/src/ast/expressions.go
@@ -42,6 +42,7 @@ type (
 	}
 
 	Literal interface {
+		Expression
 		literal()
 	}
 

--- a/src/ast/helper_visitor.go
+++ b/src/ast/helper_visitor.go
@@ -172,6 +172,14 @@ func (h *helperVisitor) VisitBadDecl(decl *BadDecl) VisitResult {
 	return VisitRecurse
 }
 
+func (h *helperVisitor) VisitConstDecl(decl *ConstDecl) VisitResult {
+	result := VisitRecurse
+	if vis, ok := h.actualVisitor.(ConstDeclVisitor); ok {
+		result = vis.VisitConstDecl(decl)
+	}
+	return h.visitChildren(result, decl.Val)
+}
+
 func (h *helperVisitor) VisitVarDecl(decl *VarDecl) VisitResult {
 	result := VisitRecurse
 	if vis, ok := h.actualVisitor.(VarDeclVisitor); ok {

--- a/src/ast/printer.go
+++ b/src/ast/printer.go
@@ -147,7 +147,7 @@ func (pr *printer) VisitBadExpr(expr *BadExpr) VisitResult {
 }
 
 func (pr *printer) VisitIdent(expr *Ident) VisitResult {
-	pr.parenthesizeNode(fmt.Sprintf("Ident[%s]", expr.Literal.Literal))
+	pr.parenthesizeNode(fmt.Sprintf("Ident[%s, %s]", expr.Literal.Literal, (*expr.Declaration).String()))
 	return VisitRecurse
 }
 

--- a/src/ast/printer.go
+++ b/src/ast/printer.go
@@ -147,7 +147,7 @@ func (pr *printer) VisitBadExpr(expr *BadExpr) VisitResult {
 }
 
 func (pr *printer) VisitIdent(expr *Ident) VisitResult {
-	pr.parenthesizeNode(fmt.Sprintf("Ident[%s, %s]", expr.Literal.Literal, (*expr.Declaration).String()))
+	pr.parenthesizeNode(fmt.Sprintf("Ident[%s, %s]", expr.Literal.Literal, expr.Declaration.String()))
 	return VisitRecurse
 }
 

--- a/src/ast/printer.go
+++ b/src/ast/printer.go
@@ -74,6 +74,15 @@ func (pr *printer) VisitBadDecl(decl *BadDecl) VisitResult {
 	return VisitRecurse
 }
 
+func (pr *printer) VisitConstDecl(decl *ConstDecl) VisitResult {
+	msg := fmt.Sprintf("ConstDecl[%s: %s]", decl.Name(), decl.Type)
+	if decl.CommentTok != nil {
+		msg += fmt.Sprintf(commentFmt, strings.Trim(decl.CommentTok.Literal, commentCutset), pr.currentIdent, " ")
+	}
+	pr.parenthesizeNode(msg, decl.Val)
+	return VisitRecurse
+}
+
 func (pr *printer) VisitVarDecl(decl *VarDecl) VisitResult {
 	msg := fmt.Sprintf("VarDecl[%s: %s]", decl.Name(), decl.Type)
 	if decl.CommentTok != nil {

--- a/src/ast/symbol_table.go
+++ b/src/ast/symbol_table.go
@@ -28,7 +28,8 @@ func (scope *SymbolTable) LookupDecl(name string) (Declaration, bool, bool) {
 		return nil, false, false
 	} else {
 		_, isVar := decl.(*VarDecl)
-		return decl, true, isVar
+		_, isConst := decl.(*ConstDecl)
+		return decl, true, isVar || isConst
 	}
 }
 

--- a/src/ast/visitor.go
+++ b/src/ast/visitor.go
@@ -25,6 +25,7 @@ type FullVisitor interface {
 	*/
 
 	BadDeclVisitor
+	ConstDeclVisitor
 	VarDeclVisitor
 	FuncDeclVisitor
 	FuncDefVisitor
@@ -79,6 +80,10 @@ type (
 	BadDeclVisitor interface {
 		Visitor
 		VisitBadDecl(*BadDecl) VisitResult
+	}
+	ConstDeclVisitor interface {
+		Visitor
+		VisitConstDecl(*ConstDecl) VisitResult
 	}
 	VarDeclVisitor interface {
 		Visitor
@@ -244,6 +249,15 @@ var _ BadDeclVisitor = (BadDeclVisitorFunc)(nil)
 
 func (BadDeclVisitorFunc) Visitor() {}
 func (f BadDeclVisitorFunc) VisitBadDecl(stmt *BadDecl) VisitResult {
+	return f(stmt)
+}
+
+type ConstDeclVisitorFunc func(*ConstDecl) VisitResult
+
+var _ ConstDeclVisitor = (ConstDeclVisitorFunc)(nil)
+
+func (ConstDeclVisitorFunc) Visitor() {}
+func (f ConstDeclVisitorFunc) VisitConstDecl(stmt *ConstDecl) VisitResult {
 	return f(stmt)
 }
 

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -456,6 +456,10 @@ func (c *compiler) VisitBadDecl(d *ast.BadDecl) ast.VisitResult {
 	return ast.VisitRecurse
 }
 
+func (c *compiler) VisitConstDecl(d *ast.ConstDecl) ast.VisitResult {
+	return ast.VisitRecurse
+}
+
 func (c *compiler) VisitVarDecl(d *ast.VarDecl) ast.VisitResult {
 	// allocate the variable on the function call frame
 	// all local variables are allocated in the first basic block of the function they are within

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -463,13 +463,7 @@ func (c *compiler) VisitConstDecl(d *ast.ConstDecl) ast.VisitResult {
 	if c.scp.enclosing == nil { // global scope
 		// globals are first assigned in ddp_main or module_init
 		// so we assign them a default value here
-		//
-		// names are mangled only in the actual ir-definitions, not in the compiler data-structures
-		globalDef := c.mod.NewGlobalDef(c.mangledNameDecl(d), Typ.DefaultValue())
-		// make private variables static like in C
-		if !d.IsPublic && !d.IsExternVisible {
-			globalDef.Linkage = enum.LinkageInternal
-		}
+		globalDef := c.mod.NewGlobalDef(d.Name(), Typ.DefaultValue())
 		globalDef.Visibility = enum.VisibilityDefault
 		varLocation = globalDef
 	} else {
@@ -688,7 +682,7 @@ func (c *compiler) VisitBadExpr(e *ast.BadExpr) ast.VisitResult {
 }
 
 func (c *compiler) VisitIdent(e *ast.Ident) ast.VisitResult {
-	Var := c.scp.lookupVar((*e.Declaration).Name()) // get the alloca in the ir
+	Var := c.scp.lookupVar(e.Declaration.Name()) // get the alloca in the ir
 	c.commentNode(c.cbb, e, e.Literal.Literal)
 
 	if Var.typ.IsPrimitive() { // primitives are simply loaded
@@ -1831,7 +1825,7 @@ func (c *compiler) VisitGrouping(e *ast.Grouping) ast.VisitResult {
 func (c *compiler) evaluateAssignableOrReference(ass ast.Assigneable, as_ref bool) (value.Value, ddpIrType, *ast.Indexing) {
 	switch assign := ass.(type) {
 	case *ast.Ident:
-		Var := c.scp.lookupVar((*assign.Declaration).Name())
+		Var := c.scp.lookupVar(assign.Declaration.Name())
 		return Var.val, Var.typ, nil
 	case *ast.Indexing:
 		lhs, lhsTyp, _ := c.evaluateAssignableOrReference(assign.Lhs, as_ref) // get the (possibly nested) assignable

--- a/src/compiler/compiler.go
+++ b/src/compiler/compiler.go
@@ -2026,6 +2026,8 @@ func (c *compiler) VisitImportStmt(s *ast.ImportStmt) ast.VisitResult {
 
 	ast.IterateImportedDecls(s, func(name string, decl ast.Declaration, _ token.Token) bool {
 		switch decl := decl.(type) {
+		case *ast.ConstDecl:
+			c.declareIfStruct(decl.Type) // not needed yet
 		case *ast.VarDecl: // declare the variable as external
 			c.declareIfStruct(decl.Type)
 			Typ := c.toIrType(decl.Type)

--- a/src/compiler/helper.go
+++ b/src/compiler/helper.go
@@ -176,10 +176,6 @@ func (c *compiler) mangledNameDecl(decl ast.Declaration) string {
 		if decl.IsExternVisible {
 			return decl.Name()
 		}
-	case *ast.ConstDecl:
-		if decl.IsExternVisible {
-			return decl.Name()
-		}
 	default:
 		// do nothing
 	}

--- a/src/compiler/helper.go
+++ b/src/compiler/helper.go
@@ -176,6 +176,10 @@ func (c *compiler) mangledNameDecl(decl ast.Declaration) string {
 		if decl.IsExternVisible {
 			return decl.Name()
 		}
+	case *ast.ConstDecl:
+		if decl.IsExternVisible {
+			return decl.Name()
+		}
 	default:
 		// do nothing
 	}

--- a/src/ddperror/messages.go
+++ b/src/ddperror/messages.go
@@ -24,7 +24,7 @@ func MsgGotExpected(got any, expected ...any) string {
 }
 
 func MsgNameAlreadyExists(name string) string {
-	return fmt.Sprintf("Der Name %s steht bereits für eine Variable, Funktion oder Struktur", name)
+	return fmt.Sprintf("Der Name %s steht bereits für eine Variable, Konstante, Funktion oder Struktur", name)
 }
 
 func MsgAliasAlreadyExists(alias, name string, isFunc bool) string {

--- a/src/parser/declarations.go
+++ b/src/parser/declarations.go
@@ -109,9 +109,7 @@ func (p *parser) constDeclaration(startDepth int) ast.Declaration {
 	expr := p.assignRhs(false) // TODO: add support for lists "N Mal x"
 	p.consumeSeq(token.DOT)
 
-	switch expr := expr.(type) {
-	case *ast.IntLit, *ast.FloatLit, *ast.BoolLit, *ast.StringLit, *ast.CharLit, *ast.ListLit:
-	default:
+	if _, isLiteral := expr.(ast.Literal); !isLiteral {
 		p.err(ddperror.SYN_EXPECTED_LITERAL, expr.GetRange(), "Es wurde ein Literal erwartet aber ein Ausdruck gefunden")
 	}
 

--- a/src/parser/declarations.go
+++ b/src/parser/declarations.go
@@ -66,8 +66,8 @@ func (p *parser) assignRhs(withComma bool) ast.Expression {
 	return expr
 }
 
-func (p *parser) matchExternSichtbar() bool {
-	if p.matchAny(token.COMMA) || p.matchAny(token.EXTERN) {
+func (p *parser) matchExternSichtbar(isPublic bool) bool {
+	if isPublic && p.matchAny(token.COMMA) || p.matchAny(token.EXTERN) {
 		if p.previous().Type == token.COMMA {
 			p.consumeSeq(token.EXTERN)
 		}
@@ -86,7 +86,7 @@ func (p *parser) constDeclaration(startDepth int) ast.Declaration {
 	comment := p.parseDeclComment(begin.Range)
 
 	isPublic := p.peekN(startDepth+1).Type == token.OEFFENTLICHE || p.peekN(startDepth+1).Type == token.OEFFENTLICHEN
-	isExternVisible := isPublic && p.matchExternSichtbar()
+	isExternVisible := p.matchExternSichtbar(isPublic)
 
 	p.consumeSeq(token.KONSTANTE)
 
@@ -139,7 +139,7 @@ func (p *parser) varDeclaration(startDepth int, isField bool) ast.Declaration {
 	comment := p.parseDeclComment(begin.Range)
 
 	isPublic := p.peekN(startDepth+1).Type == token.OEFFENTLICHE || p.peekN(startDepth+1).Type == token.OEFFENTLICHEN
-	isExternVisible := isPublic && p.matchExternSichtbar()
+	isExternVisible := p.matchExternSichtbar(isPublic)
 
 	type_start := p.peek()
 	typ := p.parseType()

--- a/src/parser/parser.go
+++ b/src/parser/parser.go
@@ -185,6 +185,8 @@ func (p *parser) declaration() ast.Statement {
 		case token.FUNKTION:
 			p.advance()
 			return p.funcDeclaration(n - 1)
+		case token.KONSTANTE:
+			return &ast.DeclStmt{Decl: p.constDeclaration(n)}
 		default:
 			return &ast.DeclStmt{Decl: p.varDeclaration(n, false)}
 		}

--- a/src/parser/resolver/resolver.go
+++ b/src/parser/resolver/resolver.go
@@ -204,7 +204,7 @@ func (r *Resolver) VisitIdent(expr *ast.Ident) ast.VisitResult {
 	} else if !isVar {
 		r.err(ddperror.SEM_BAD_NAME_CONTEXT, expr.Token().Range, fmt.Sprintf("Der Name '%s' steht für eine Funktion oder Struktur und nicht für eine Variable", expr.Literal.Literal))
 	} else { // set the reference to the declaration
-		expr.Declaration = decl.(*ast.VarDecl)
+		expr.Declaration = &decl
 	}
 	return ast.VisitRecurse
 }
@@ -358,8 +358,10 @@ func (r *Resolver) VisitAssignStmt(stmt *ast.AssignStmt) ast.VisitResult {
 			r.err(ddperror.SEM_NAME_UNDEFINED, assign.Literal.Range, fmt.Sprintf("Der Name '%s' wurde in noch nicht als Variable deklariert", assign.Literal.Literal))
 		} else if !isVar {
 			r.err(ddperror.SEM_BAD_NAME_CONTEXT, assign.Token().Range, fmt.Sprintf("Der Name '%s' steht für eine Funktion oder Struktur und nicht für eine Variable", assign.Literal.Literal))
+		} else if _, isConst := varDecl.(*ast.ConstDecl); isConst {
+			r.err(ddperror.SEM_BAD_NAME_CONTEXT, assign.Token().Range, fmt.Sprintf("Der Name '%s' steht für einer Konstante und kann daher nicht zugewiesen werden", assign.Literal.Literal))
 		} else { // set the reference to the declaration
-			assign.Declaration = varDecl.(*ast.VarDecl)
+			assign.Declaration = &varDecl
 		}
 	case *ast.Indexing:
 		r.visit(assign.Lhs)

--- a/src/parser/resolver/resolver.go
+++ b/src/parser/resolver/resolver.go
@@ -204,7 +204,7 @@ func (r *Resolver) VisitIdent(expr *ast.Ident) ast.VisitResult {
 	} else if !isVar {
 		r.err(ddperror.SEM_BAD_NAME_CONTEXT, expr.Token().Range, fmt.Sprintf("Der Name '%s' steht für eine Funktion oder Struktur und nicht für eine Variable", expr.Literal.Literal))
 	} else { // set the reference to the declaration
-		expr.Declaration = &decl
+		expr.Declaration = decl
 	}
 	return ast.VisitRecurse
 }
@@ -361,7 +361,7 @@ func (r *Resolver) VisitAssignStmt(stmt *ast.AssignStmt) ast.VisitResult {
 		} else if _, isConst := varDecl.(*ast.ConstDecl); isConst {
 			r.err(ddperror.SEM_BAD_NAME_CONTEXT, assign.Token().Range, fmt.Sprintf("Der Name '%s' steht für einer Konstante und kann daher nicht zugewiesen werden", assign.Literal.Literal))
 		} else { // set the reference to the declaration
-			assign.Declaration = &varDecl
+			assign.Declaration = varDecl
 		}
 	case *ast.Indexing:
 		r.visit(assign.Lhs)

--- a/src/parser/statements.go
+++ b/src/parser/statements.go
@@ -278,9 +278,7 @@ func (p *parser) assignLiteral() ast.Statement {
 	p.consumeSeq(token.IST)
 	expr := p.assignRhs(false) // parse the expression
 	// validate that the expression is a literal
-	switch expr := expr.(type) {
-	case *ast.IntLit, *ast.FloatLit, *ast.BoolLit, *ast.StringLit, *ast.CharLit, *ast.ListLit:
-	default:
+	if _, isLiteral := expr.(ast.Literal); !isLiteral {
 		if typ := p.typechecker.Evaluate(ident); !ddptypes.Equal(typ, ddptypes.WAHRHEITSWERT) {
 			p.err(ddperror.SYN_EXPECTED_LITERAL, expr.GetRange(), "Es wurde ein Literal erwartet aber ein Ausdruck gefunden")
 		}

--- a/src/parser/typechecker/assignable_checker.go
+++ b/src/parser/typechecker/assignable_checker.go
@@ -19,7 +19,6 @@ func isAssignable(expr ast.Expression) (ast.Assigneable, bool) {
 	default:
 		return nil, false
 	}
-	return nil, false
 }
 
 func isBinaryExprAssignable(expr *ast.BinaryExpr) (ast.Assigneable, bool) {

--- a/src/parser/typechecker/typechecker.go
+++ b/src/parser/typechecker/typechecker.go
@@ -194,7 +194,12 @@ func (t *Typechecker) VisitIdent(expr *ast.Ident) ast.VisitResult {
 	if !ok || !isVar || decl == nil {
 		t.latestReturnedType = ddptypes.VoidType{}
 	} else {
-		t.latestReturnedType = decl.(*ast.VarDecl).Type
+		switch decl := decl.(type) {
+		case *ast.VarDecl:
+			t.latestReturnedType = decl.Type
+		case *ast.ConstDecl:
+			t.latestReturnedType = decl.Type
+		}
 	}
 	return ast.VisitRecurse
 }

--- a/src/parser/typechecker/typechecker.go
+++ b/src/parser/typechecker/typechecker.go
@@ -199,6 +199,7 @@ func (t *Typechecker) VisitIdent(expr *ast.Ident) ast.VisitResult {
 			t.latestReturnedType = decl.Type
 		case *ast.ConstDecl:
 			t.latestReturnedType = decl.Type
+		default:
 		}
 	}
 	return ast.VisitRecurse

--- a/src/parser/typechecker/typechecker.go
+++ b/src/parser/typechecker/typechecker.go
@@ -103,6 +103,16 @@ func (t *Typechecker) VisitBadDecl(decl *ast.BadDecl) ast.VisitResult {
 	return ast.VisitRecurse
 }
 
+func (t *Typechecker) VisitConstDecl(decl *ast.ConstDecl) ast.VisitResult {
+	decl.Type = t.Evaluate(decl.Val)
+
+	if decl.Public() && !IsPublicType(decl.Type, t.CurrentTable) {
+		t.err(ddperror.SEM_BAD_PUBLIC_MODIFIER, decl.Range, "Der Typ einer öffentlichen Konstante muss ebenfalls öffentlich sein")
+	}
+
+	return ast.VisitRecurse
+}
+
 func (t *Typechecker) VisitVarDecl(decl *ast.VarDecl) ast.VisitResult {
 	initialType := t.Evaluate(decl.InitVal)
 	decl.InitType = initialType

--- a/src/parser/typechecker/typechecker.go
+++ b/src/parser/typechecker/typechecker.go
@@ -273,9 +273,8 @@ func (t *Typechecker) VisitListLit(expr *ast.ListLit) ast.VisitResult {
 		if count := t.Evaluate(expr.Count); !ddptypes.Equal(count, ddptypes.ZAHL) {
 			t.errExpr(ddperror.TYP_BAD_LIST_LITERAL, expr, "Die Größe einer Liste muss als Zahl angegeben werden, nicht als %s", count)
 		}
-		if val := t.Evaluate(expr.Value); !ddptypes.Equal(val, expr.Type.Underlying) {
-			t.errExpr(ddperror.TYP_BAD_LIST_LITERAL, expr, "Falscher Typ (%s) in Listen Literal vom Typ %s", val, expr.Type.Underlying)
-		}
+
+		expr.Type = ddptypes.ListType{Underlying: t.Evaluate(expr.Value)}
 	}
 	t.latestReturnedType = expr.Type
 	return ast.VisitRecurse

--- a/src/token/token_types.go
+++ b/src/token/token_types.go
@@ -158,6 +158,7 @@ const (
 	ALLE
 	MODULE
 	INDEX
+	KONSTANTE
 
 	DOT     // .
 	COMMA   // ,
@@ -325,6 +326,7 @@ var tokenStrings = [...]string{
 	ALLE:          "alle",
 	MODULE:        "Module",
 	INDEX:         "Index",
+	KONSTANTE:     "Konstante",
 
 	DOT:     ".",
 	COMMA:   ",",
@@ -497,6 +499,7 @@ var KeywordMap = map[string]TokenType{
 	"alle":           ALLE,
 	"Module":         MODULE,
 	"Index":          INDEX,
+	"Konstante":      KONSTANTE,
 }
 
 func KeywordToTokenType(keyword string) TokenType {

--- a/tests/testdata/kddp/consts/consts.ddp
+++ b/tests/testdata/kddp/consts/consts.ddp
@@ -1,0 +1,25 @@
+Binde "Duden/Ausgabe" ein.
+
+Die Konstante k_z ist 4.
+Die Konstante k_k ist 4,2.
+Die Konstante k_w ist wahr.
+Die Konstante k_b ist 'g'.
+Die Konstante k_t ist "hallo welt".
+Die Konstante k_t2 ist "".
+Die Konstante k_lz ist eine Liste, die aus 3, 5, 6 besteht.
+Die Konstante k_lk ist eine Liste, die aus 3,2, 5,76, 6,0 besteht.
+Die Konstante k_lw ist eine Liste, die aus wahr, falsch, wahr besteht.
+Die Konstante k_lb ist eine Liste, die aus 'd', 'a', 'd' besteht.
+Die Konstante k_lt ist eine Liste, die aus "hallo welt", "yo", "" besteht.
+
+Schreibe k_z auf eine Zeile.
+Schreibe k_k auf eine Zeile.
+Schreibe k_w auf eine Zeile.
+Schreibe k_b auf eine Zeile.
+Schreibe k_t auf eine Zeile.
+Schreibe k_t2 auf eine Zeile.
+Schreibe k_lz auf eine Zeile.
+Schreibe k_lk auf eine Zeile.
+Schreibe k_lw auf eine Zeile.
+Schreibe k_lb auf eine Zeile.
+Schreibe k_lt auf eine Zeile.

--- a/tests/testdata/kddp/consts/consts.ddp
+++ b/tests/testdata/kddp/consts/consts.ddp
@@ -11,6 +11,7 @@ Die Konstante k_lk ist eine Liste, die aus 3,2, 5,76, 6,0 besteht.
 Die Konstante k_lw ist eine Liste, die aus wahr, falsch, wahr besteht.
 Die Konstante k_lb ist eine Liste, die aus 'd', 'a', 'd' besteht.
 Die Konstante k_lt ist eine Liste, die aus "hallo welt", "yo", "" besteht.
+Die Konstante k_m ist 5 Mal 2.
 
 Schreibe k_z auf eine Zeile.
 Schreibe k_k auf eine Zeile.
@@ -23,3 +24,4 @@ Schreibe k_lk auf eine Zeile.
 Schreibe k_lw auf eine Zeile.
 Schreibe k_lb auf eine Zeile.
 Schreibe k_lt auf eine Zeile.
+Schreibe k_m auf eine Zeile.

--- a/tests/testdata/kddp/consts/expected.txt
+++ b/tests/testdata/kddp/consts/expected.txt
@@ -9,3 +9,4 @@ hallo welt
 wahr, falsch, wahr
 d, a, d
 hallo welt, yo, 
+2, 2, 2, 2, 2

--- a/tests/testdata/kddp/consts/expected.txt
+++ b/tests/testdata/kddp/consts/expected.txt
@@ -1,0 +1,11 @@
+4
+4,2
+wahr
+g
+hallo welt
+
+3, 5, 6
+3,2, 5,76, 6
+wahr, falsch, wahr
+d, a, d
+hallo welt, yo, 


### PR DESCRIPTION
Implementiert Kompilierzeit-Konstante. Die Syntax lautet:
```
Die Konstante foo ist 5.
```
Siehe #97 für weitere Informationen.